### PR TITLE
Fix download script, update wanaku router/cli/http-service links

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,25 +33,25 @@ Tests require Router, HTTP Capability, File Provider, and CLI JARs. Choose one o
 WANAKU_DIR=/path/to/wanaku
 EXAMPLES_DIR=/path/to/wanaku-examples
 
-cp -r $WANAKU_DIR/wanaku/wanaku-router/target/quarkus-app artifacts/wanaku-router-backend-0.1.0-SNAPSHOT
-cp -r $WANAKU_DIR/wanaku/capabilities/tools/wanaku-tool-service-http/target/quarkus-app artifacts/wanaku-tool-service-http-0.1.0-SNAPSHOT
+cp -r $WANAKU_DIR/wanaku/wanaku-router/target/quarkus-app artifacts/wanaku-router-backend-0.1.0
+cp -r $WANAKU_DIR/wanaku/capabilities/tools/wanaku-tool-service-http/target/quarkus-app artifacts/wanaku-tool-service-http-0.1.0
 cp -r $EXAMPLES_DIR/providers/wanaku-provider-file/target/quarkus-app artifacts/wanaku-provider-file
-cp -r $WANAKU_DIR/wanaku/cli/target/quarkus-app artifacts/wanaku-cli-0.1.0-SNAPSHOT
+cp -r $WANAKU_DIR/wanaku/cli/target/quarkus-app artifacts/wanaku-cli-0.1.0
 ```
 
 After setup:
 ```
 artifacts/
-├── wanaku-router-backend-0.1.0-SNAPSHOT/
+├── wanaku-router-backend-0.1.0/
 │   ├── quarkus-run.jar
 │   └── lib/
-├── wanaku-tool-service-http-0.1.0-SNAPSHOT/
+├── wanaku-tool-service-http-0.1.0/
 │   ├── quarkus-run.jar
 │   └── lib/
 ├── wanaku-provider-file/
 │   ├── quarkus-run.jar
 │   └── lib/
-└── wanaku-cli-0.1.0-SNAPSHOT/
+└── wanaku-cli-0.1.0/
     ├── quarkus-run.jar
     └── lib/
 ```
@@ -63,7 +63,7 @@ CLI tests require `wanaku` CLI. Choose one option:
 **Option A: Use CLI JAR from artifacts**
 ```bash
 # Set system property to point to CLI JAR
-mvn clean install -Dwanaku.test.cli.path=../artifacts/wanaku-cli-0.1.0-SNAPSHOT/quarkus-run.jar
+mvn clean install -Dwanaku.test.cli.path=../artifacts/wanaku-cli-0.1.0/quarkus-run.jar
 ```
 
 **Option B: Install globally via jbang**
@@ -80,7 +80,7 @@ wanaku --version
 
 ```bash
 # Recommended: build and run all tests with CLI JAR and debug logging
-mvn clean install -Dwanaku.test.cli.path=../artifacts/wanaku-cli-0.1.0-SNAPSHOT/quarkus-run.jar -Dwanaku.log.level=DEBUG
+mvn clean install -Dwanaku.test.cli.path=../artifacts/wanaku-cli-0.1.0/quarkus-run.jar -Dwanaku.log.level=DEBUG
 
 # Build and run all tests (requires wanaku CLI installed via jbang)
 mvn clean install
@@ -92,7 +92,7 @@ mvn clean install -pl http-capability-tests -Dtest=HttpToolRegistrationITCase#sh
 mvn clean install -Dwanaku.log.level=DEBUG
 
 # Run with CLI JAR instead of system CLI
-mvn clean install -Dwanaku.test.cli.path=../artifacts/wanaku-cli-0.1.0-SNAPSHOT/quarkus-run.jar
+mvn clean install -Dwanaku.test.cli.path=../artifacts/wanaku-cli-0.1.0/quarkus-run.jar
 ```
 
 ## Project Structure

--- a/artifacts/download.sh
+++ b/artifacts/download.sh
@@ -8,9 +8,9 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-ROUTER_URL="https://github.com/wanaku-ai/wanaku/releases/download/early-access/wanaku-router-backend-0.1.0-SNAPSHOT.zip"
-HTTP_URL="https://github.com/wanaku-ai/wanaku/releases/download/early-access/wanaku-tool-service-http-0.1.0-SNAPSHOT.zip"
-CLI_URL="https://github.com/wanaku-ai/wanaku/releases/download/early-access/wanaku-cli-0.1.0-SNAPSHOT.zip"
+ROUTER_URL="https://github.com/wanaku-ai/wanaku/releases/download/v0.1.0/wanaku-router-backend-0.1.0.zip"
+HTTP_URL="https://github.com/wanaku-ai/wanaku/releases/download/v0.1.0/wanaku-tool-service-http-0.1.0.zip"
+CLI_URL="https://github.com/wanaku-ai/wanaku/releases/download/v0.1.0/wanaku-cli-0.1.0.zip"
 FILE_PROVIDER_URL="https://github.com/wanaku-ai/wanaku-examples/releases/download/early-access/wanaku-provider-file-0.1.0-SNAPSHOT.zip"
 CIC_URL="https://github.com/wanaku-ai/camel-integration-capability/releases/download/early-access/camel-integration-capability-main-0.1.0-SNAPSHOT-jar-with-dependencies.jar"
 


### PR DESCRIPTION
@orpiske @matheusandre1

## Summary by Sourcery

Update artifact names and download URLs to align with the 0.1.0 release artifacts instead of SNAPSHOT builds.

Bug Fixes:
- Fix download script URLs to point to the released v0.1.0 router, HTTP tool service, and CLI archives rather than early-access SNAPSHOT zips.

Enhancements:
- Adjust README setup instructions and example paths to use non-SNAPSHOT 0.1.0 artifact directory names for router, HTTP tool service, and CLI.