### PR TITLE
Fix CLI availability check for CI environments

### DIFF
--- a/test-common/src/main/java/ai/wanaku/test/client/CLIExecutor.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/CLIExecutor.java
@@ -128,19 +128,28 @@ public class CLIExecutor {
 
     /**
      * Checks if the CLI is available.
-     * Note: Wanaku CLI may return exit code 1 for --version even when working correctly,
-     * so we check for output presence (stdout or stderr) instead of just exit code.
+     * For JAR-based CLIs, verifies the file exists (avoids unreliable --version subprocess).
+     * For binary CLIs, attempts to execute --version.
      */
     public boolean isAvailable() {
+        if (cliPath.endsWith(".jar")) {
+            Path jarPath = Path.of(cliPath).toAbsolutePath().normalize();
+            boolean exists = jarPath.toFile().exists();
+            if (!exists) {
+                LOG.warn("CLI JAR not found at resolved path '{}'", jarPath);
+            }
+            return exists;
+        }
+
         try {
             CLIResult result = execute("--version");
-            // Exit code -1 indicates an error (IOException, timeout, etc.)
-            if (result.getExitCode() == -1) {
-                return false;
+            boolean available = result.getExitCode() != -1;
+            if (!available) {
+                LOG.warn("CLI not available at '{}': {}", cliPath, result.getCombinedOutput());
             }
-            // CLI is available if it produces any output or exits successfully
-            return !result.getCombinedOutput().isEmpty() || result.isSuccess();
+            return available;
         } catch (Exception e) {
+            LOG.warn("CLI availability check failed: {}", e.getMessage());
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- Fix `CLIExecutor.isAvailable()` returning false when the CLI is installed but `--version` output goes to `/dev/tty` instead of stdout
- The `--plain` flag is not appended for flags starting with `-`, so version output may not be captured in stdout/stderr
- Combined with Quarkus picocli returning exit code 1 for `--version`, the old check (`!output.isEmpty() || exitCode == 0`) failed
- Now treats any exit code other than -1 (our sentinel for IOException/timeout) as "CLI is available"

## Test plan
- [ ] Verify `HttpToolCliITCase` tests pass in CI
- [ ] Verify tests still skip/fail gracefully when CLI binary is genuinely missing

## Summary by Sourcery

Update CLI availability check logic to treat any non-sentinel exit code as indicating a present and executable CLI binary.

Bug Fixes:
- Fix false negatives in CLI availability detection when the CLI returns a non-zero exit code or writes version output outside of captured stdout/stderr.

Enhancements:
- Add diagnostic logging when the CLI is not available or when the availability check itself fails.