### PR TITLE
Parameterize download script version with snapshot support

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Tests require Router, HTTP Capability, File Provider, and CLI JARs. Choose one o
 
 **Option A: Download from GitHub releases (recommended)**
 ```bash
-./artifacts/download.sh
+./artifacts/download.sh 0.1.0             # release
+./artifacts/download.sh 0.1.1-SNAPSHOT    # snapshot (early-access)
 ```
 
 **Option B: Copy from local Wanaku build**

--- a/artifacts/download.sh
+++ b/artifacts/download.sh
@@ -1,18 +1,41 @@
 #!/bin/bash
 #
 # Downloads pre-built Wanaku artifacts from GitHub releases.
-# Usage: ./artifacts/download.sh
+# Usage: ./artifacts/download.sh <version>
+# Examples:
+#   ./artifacts/download.sh 0.1.0              # release
+#   ./artifacts/download.sh 0.1.1-SNAPSHOT     # snapshot (early-access)
 #
 
 set -euo pipefail
 
+if [ $# -ne 1 ]; then
+    echo "Usage: $0 <version>" >&2
+    echo "Example: $0 0.1.0" >&2
+    exit 1
+fi
+
+VERSION="$1"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-ROUTER_URL="https://github.com/wanaku-ai/wanaku/releases/download/v0.1.0/wanaku-router-backend-0.1.0.zip"
-HTTP_URL="https://github.com/wanaku-ai/wanaku/releases/download/v0.1.0/wanaku-tool-service-http-0.1.0.zip"
-CLI_URL="https://github.com/wanaku-ai/wanaku/releases/download/v0.1.0/wanaku-cli-0.1.0.zip"
-FILE_PROVIDER_URL="https://github.com/wanaku-ai/wanaku-examples/releases/download/v0.1.0/wanaku-provider-file-0.1.0.zip"
-CIC_URL="https://github.com/wanaku-ai/camel-integration-capability/releases/download/v0.1.0/camel-integration-capability-main-0.1.0-jar-with-dependencies.jar"
+if [[ "$VERSION" == *-SNAPSHOT ]]; then
+    TAG="early-access"
+    OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
+    ARCH="$(uname -m)"
+    case "$ARCH" in
+        arm64) ARCH="aarch64" ;;
+    esac
+    PLATFORM="-${OS}-${ARCH}"
+else
+    TAG="v${VERSION}"
+    PLATFORM=""
+fi
+
+ROUTER_URL="https://github.com/wanaku-ai/wanaku/releases/download/${TAG}/wanaku-router-backend-${VERSION}.zip"
+HTTP_URL="https://github.com/wanaku-ai/wanaku/releases/download/${TAG}/wanaku-tool-service-http-${VERSION}.zip"
+CLI_URL="https://github.com/wanaku-ai/wanaku/releases/download/${TAG}/wanaku-cli-${VERSION}${PLATFORM}.zip"
+FILE_PROVIDER_URL="https://github.com/wanaku-ai/wanaku-examples/releases/download/${TAG}/wanaku-provider-file-${VERSION}.zip"
+CIC_URL="https://github.com/wanaku-ai/camel-integration-capability/releases/download/${TAG}/camel-integration-capability-main-${VERSION}-jar-with-dependencies.jar"
 
 download_and_extract() {
     local url="$1"
@@ -48,7 +71,7 @@ download_jar() {
     echo "${filename} ready."
 }
 
-download_jar "${CIC_URL}" "camel-integration-capability" "camel-integration-capability-main-0.1.0-SNAPSHOT-jar-with-dependencies.jar"
+download_jar "${CIC_URL}" "camel-integration-capability" "camel-integration-capability-main-${VERSION}-jar-with-dependencies.jar"
 
 echo ""
 echo "All artifacts downloaded to ${SCRIPT_DIR}"

--- a/artifacts/download.sh
+++ b/artifacts/download.sh
@@ -11,8 +11,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 ROUTER_URL="https://github.com/wanaku-ai/wanaku/releases/download/v0.1.0/wanaku-router-backend-0.1.0.zip"
 HTTP_URL="https://github.com/wanaku-ai/wanaku/releases/download/v0.1.0/wanaku-tool-service-http-0.1.0.zip"
 CLI_URL="https://github.com/wanaku-ai/wanaku/releases/download/v0.1.0/wanaku-cli-0.1.0.zip"
-FILE_PROVIDER_URL="https://github.com/wanaku-ai/wanaku-examples/releases/download/early-access/wanaku-provider-file-0.1.0-SNAPSHOT.zip"
-CIC_URL="https://github.com/wanaku-ai/camel-integration-capability/releases/download/early-access/camel-integration-capability-main-0.1.0-SNAPSHOT-jar-with-dependencies.jar"
+FILE_PROVIDER_URL="https://github.com/wanaku-ai/wanaku-examples/releases/download/v0.1.0/wanaku-provider-file-0.1.0.zip"
+CIC_URL="https://github.com/wanaku-ai/camel-integration-capability/releases/download/v0.1.0/camel-integration-capability-main-0.1.0-jar-with-dependencies.jar"
 
 download_and_extract() {
     local url="$1"

--- a/camel-integration-capability-tests/README.md
+++ b/camel-integration-capability-tests/README.md
@@ -8,7 +8,7 @@ Required artifacts are downloaded via:
 
 ```bash
 cd ..
-./artifacts/download.sh
+./artifacts/download.sh 0.1.0
 ```
 
 Docker is required for Keycloak (all tests) and PostgreSQL (database tests).

--- a/http-capability-tests/README.md
+++ b/http-capability-tests/README.md
@@ -8,10 +8,10 @@ Required artifacts are downloaded via:
 
 ```bash
 cd ..
-./artifacts/download.sh
+./artifacts/download.sh 0.1.0
 ```
 
-This downloads Router, HTTP Tool Service, and CLI from [wanaku releases](https://github.com/wanaku-ai/wanaku/releases/tag/early-access).
+This downloads Router, HTTP Tool Service, and CLI from [wanaku releases](https://github.com/wanaku-ai/wanaku/releases).
 
 ## Run Tests
 

--- a/resources-tests/README.md
+++ b/resources-tests/README.md
@@ -8,10 +8,10 @@ File provider JAR is required. Download via:
 
 ```bash
 cd ..
-./artifacts/download.sh
+./artifacts/download.sh 0.1.0
 ```
 
-This downloads `wanaku-provider-file` from [wanaku-examples releases](https://github.com/wanaku-ai/wanaku-examples/releases/tag/early-access).
+This downloads `wanaku-provider-file` from [wanaku-examples releases](https://github.com/wanaku-ai/wanaku-examples/releases).
 
 ## Run Tests
 

--- a/test-common/src/main/java/ai/wanaku/test/client/CLIExecutor.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/CLIExecutor.java
@@ -128,19 +128,28 @@ public class CLIExecutor {
 
     /**
      * Checks if the CLI is available.
-     * Note: Wanaku CLI may return exit code 1 for --version even when working correctly,
-     * so we check for output presence (stdout or stderr) instead of just exit code.
+     * For JAR-based CLIs, verifies the file exists (avoids unreliable --version subprocess).
+     * For binary CLIs, attempts to execute --version.
      */
     public boolean isAvailable() {
+        if (cliPath.endsWith(".jar")) {
+            Path jarPath = Path.of(cliPath).toAbsolutePath().normalize();
+            boolean exists = jarPath.toFile().exists();
+            if (!exists) {
+                LOG.warn("CLI JAR not found at resolved path '{}'", jarPath);
+            }
+            return exists;
+        }
+
         try {
             CLIResult result = execute("--version");
-            // Exit code -1 indicates an error (IOException, timeout, etc.)
-            if (result.getExitCode() == -1) {
-                return false;
+            boolean available = result.getExitCode() != -1;
+            if (!available) {
+                LOG.warn("CLI not available at '{}': {}", cliPath, result.getCombinedOutput());
             }
-            // CLI is available if it produces any output or exits successfully
-            return !result.getCombinedOutput().isEmpty() || result.isSuccess();
+            return available;
         } catch (Exception e) {
+            LOG.warn("CLI availability check failed: {}", e.getMessage());
             return false;
         }
     }


### PR DESCRIPTION
## Summary
- Accept version as a required argument to `artifacts/download.sh` (e.g., `./artifacts/download.sh 0.1.0`)
- For SNAPSHOT versions (e.g., `0.1.1-SNAPSHOT`), use the `early-access` release tag and append platform suffix (`-linux-x86_64`, `-darwin-aarch64`) to the CLI artifact (native binary only)
- Update all READMEs with new usage examples

## Test plan
- [ ] Run `./artifacts/download.sh 0.1.0` and verify release artifacts download correctly
- [ ] Run `./artifacts/download.sh 0.1.1-SNAPSHOT` and verify snapshot artifacts download from early-access tag with correct platform suffix on CLI

## Summary by Sourcery

Parameterize artifact download tooling and update CLI availability checks.

Enhancements:
- Make artifacts/download.sh require an explicit version argument and derive GitHub release tags and platform-specific CLI artifact names, including snapshot support via the early-access tag.
- Adjust CLIExecutor availability checks to treat JAR-based CLIs as present if the JAR file exists and to log failures for binary CLIs more clearly.

Documentation:
- Update README usage examples to show versioned download.sh invocation for both release and snapshot artifacts and to reference generic GitHub releases instead of a fixed early-access tag.