### PR TITLE
chore: switch from surefire to failsafe for integration tests

### DIFF
--- a/camel-integration-capability-tests/pom.xml
+++ b/camel-integration-capability-tests/pom.xml
@@ -80,11 +80,9 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
+                <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <!-- Enable random test order for isolation verification -->
                     <runOrder>random</runOrder>
-                    <!-- Pass system properties to tests -->
                     <systemPropertyVariables>
                         <wanaku.test.artifacts.dir>${project.basedir}/../artifacts</wanaku.test.artifacts.dir>
                     </systemPropertyVariables>

--- a/http-capability-tests/pom.xml
+++ b/http-capability-tests/pom.xml
@@ -73,11 +73,9 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
+                <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <!-- Enable random test order for isolation verification -->
                     <runOrder>random</runOrder>
-                    <!-- Pass system properties to tests -->
                     <systemPropertyVariables>
                         <wanaku.test.artifacts.dir>${project.basedir}/../artifacts</wanaku.test.artifacts.dir>
                     </systemPropertyVariables>

--- a/pom.xml
+++ b/pom.xml
@@ -39,7 +39,7 @@
 
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-        <maven-surefire-plugin.version>3.2.5</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.2.5</maven-failsafe-plugin.version>
         <spotless-maven-plugin.version>3.4.0</spotless-maven-plugin.version>
         <palantir-format-version.version>2.71.0</palantir-format-version.version>
     </properties>
@@ -153,14 +153,19 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-surefire-plugin</artifactId>
-                    <version>${maven-surefire-plugin.version}</version>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
                     <configuration>
-                        <includes>
-                            <include>**/*ITCase.java</include>
-                        </includes>
                         <argLine>-Xmx1024m</argLine>
                     </configuration>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>com.diffplug.spotless</groupId>

--- a/resources-tests/pom.xml
+++ b/resources-tests/pom.xml
@@ -73,11 +73,9 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
+                <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
-                    <!-- Enable random test order for isolation verification -->
                     <runOrder>random</runOrder>
-                    <!-- Pass system properties to tests -->
                     <systemPropertyVariables>
                         <wanaku.test.artifacts.dir>${project.basedir}/../artifacts</wanaku.test.artifacts.dir>
                     </systemPropertyVariables>


### PR DESCRIPTION
## Summary
- Replace maven-surefire-plugin with maven-failsafe-plugin so integration tests run during the `integration-test`/`verify` lifecycle phases instead of the `test` phase
- Failsafe's default includes already match the `*ITCase.java` naming convention, so explicit include patterns are no longer needed
- The test-common module's unit test (`TargetConfigurationTest`) continues to run under surefire defaults

## Test plan
- [ ] Run `mvn verify` and confirm all `*ITCase` tests execute during the integration-test phase
- [ ] Confirm `test-common` unit test still runs during the test phase