### PR TITLE
ci: add integration tests workflow with dispatch and nightly triggers

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,71 @@
+name: Integration Tests
+
+on:
+  repository_dispatch:
+    types: [wanaku-build-completed]
+
+  schedule:
+    # Nightly at 03:17 UTC
+    - cron: '17 3 * * *'
+
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Wanaku version to test (e.g., 0.3.0-SNAPSHOT or 0.2.0)'
+        required: false
+        default: ''
+
+env:
+  # Update when upstream development version changes
+  DEFAULT_SNAPSHOT_VERSION: '0.3.0-SNAPSHOT'
+
+jobs:
+  integration-tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Determine version
+        id: version
+        run: |
+          if [ "${{ github.event_name }}" = "repository_dispatch" ]; then
+            VERSION="${{ github.event.client_payload.version }}"
+          elif [ "${{ github.event_name }}" = "workflow_dispatch" ] && [ -n "${{ github.event.inputs.version }}" ]; then
+            VERSION="${{ github.event.inputs.version }}"
+          else
+            VERSION="${{ env.DEFAULT_SNAPSHOT_VERSION }}"
+          fi
+
+          if [ -z "$VERSION" ]; then
+            echo "::error::No version could be determined"
+            exit 1
+          fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "### Version: \`${VERSION}\`" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Download artifacts
+        run: |
+          chmod +x ./artifacts/download.sh
+          ./artifacts/download.sh "${{ steps.version.outputs.version }}"
+
+      - name: Run integration tests
+        run: mvn -B verify --file pom.xml
+
+      - name: Upload test reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: integration-test-reports
+          path: |
+            **/target/failsafe-reports/
+          retention-days: 14
+          if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- Adds a new `integration-tests.yml` workflow that replaces the old Jenkins job for running integration tests after upstream wanaku builds
- Supports three triggers: `repository_dispatch` (from upstream early-access workflow), nightly cron schedule (safety net), and manual `workflow_dispatch`
- Downloads artifacts via the existing `download.sh`, runs `mvn verify` across all test modules, and uploads failsafe reports

## Test plan

- [ ] Trigger manually with `gh workflow run integration-tests.yml -f version=0.1.0` and verify artifact download + test execution
- [ ] Verify nightly cron fires and uses `DEFAULT_SNAPSHOT_VERSION`
- [ ] After wiring the sender in `wanaku-ai/wanaku` early-access workflow, verify `repository_dispatch` triggers correctly

## Summary by Sourcery

CI:
- Introduce an Integration Tests workflow triggered by repository_dispatch, nightly cron schedule, and manual workflow_dispatch to replace the prior Jenkins-based integration testing.