### PR TITLE
ci: add test results summary table to job summary

### DIFF
--- a/.github/scripts/test-summary.sh
+++ b/.github/scripts/test-summary.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+set -euo pipefail
+
+echo "## Test Results" >> "$GITHUB_STEP_SUMMARY"
+echo "" >> "$GITHUB_STEP_SUMMARY"
+echo "| Module | Tests | Passed | Failed | Errors | Skipped | Time |" >> "$GITHUB_STEP_SUMMARY"
+echo "|--------|------:|-------:|-------:|-------:|--------:|-----:|" >> "$GITHUB_STEP_SUMMARY"
+
+total_tests=0 total_fail=0 total_err=0 total_skip=0 total_time=0
+
+for module in http-capability-tests resources-tests camel-integration-capability-tests; do
+  dir="${module}/target/failsafe-reports"
+  if [ ! -d "$dir" ]; then
+    echo "| ${module} | - | - | - | - | - | - |" >> "$GITHUB_STEP_SUMMARY"
+    continue
+  fi
+
+  mod_tests=0 mod_fail=0 mod_err=0 mod_skip=0 mod_time=0
+  for f in "$dir"/TEST-*.xml; do
+    [ -f "$f" ] || continue
+    tests=$(grep -oP 'tests="\K[0-9]+' "$f" | head -1)
+    failures=$(grep -oP 'failures="\K[0-9]+' "$f" | head -1)
+    errors=$(grep -oP 'errors="\K[0-9]+' "$f" | head -1)
+    skipped=$(grep -oP 'skipped="\K[0-9]+' "$f" | head -1)
+    time=$(grep -oP 'time="\K[0-9.]+' "$f" | head -1)
+    mod_tests=$((mod_tests + ${tests:-0}))
+    mod_fail=$((mod_fail + ${failures:-0}))
+    mod_err=$((mod_err + ${errors:-0}))
+    mod_skip=$((mod_skip + ${skipped:-0}))
+    mod_time=$(echo "$mod_time + ${time:-0}" | bc)
+  done
+
+  passed=$((mod_tests - mod_fail - mod_err - mod_skip))
+  echo "| ${module} | ${mod_tests} | ${passed} | ${mod_fail} | ${mod_err} | ${mod_skip} | ${mod_time}s |" >> "$GITHUB_STEP_SUMMARY"
+
+  total_tests=$((total_tests + mod_tests))
+  total_fail=$((total_fail + mod_fail))
+  total_err=$((total_err + mod_err))
+  total_skip=$((total_skip + mod_skip))
+  total_time=$(echo "$total_time + $mod_time" | bc)
+done
+
+total_passed=$((total_tests - total_fail - total_err - total_skip))
+echo "| **Total** | **${total_tests}** | **${total_passed}** | **${total_fail}** | **${total_err}** | **${total_skip}** | **${total_time}s** |" >> "$GITHUB_STEP_SUMMARY"
+
+if [ "$total_fail" -gt 0 ] || [ "$total_err" -gt 0 ]; then
+  echo "" >> "$GITHUB_STEP_SUMMARY"
+  echo "### Failed Tests" >> "$GITHUB_STEP_SUMMARY"
+  echo "" >> "$GITHUB_STEP_SUMMARY"
+  for f in **/target/failsafe-reports/TEST-*.xml; do
+    [ -f "$f" ] || continue
+    grep -l 'failures="[1-9]\|errors="[1-9]' "$f" > /dev/null 2>&1 || continue
+    classname=$(grep -oP 'name="\K[^"]+' "$f" | head -1)
+    grep -oP '<testcase name="\K[^"]+' "$f" | while read -r tc; do
+      if grep -A5 "name=\"${tc}\"" "$f" | grep -q '<failure\|<error'; then
+        echo "- \`${classname}#${tc}\`" >> "$GITHUB_STEP_SUMMARY"
+      fi
+    done
+  done
+fi

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -60,6 +60,10 @@ jobs:
       - name: Run integration tests
         run: mvn -B verify --file pom.xml
 
+      - name: Test summary
+        if: always()
+        run: ./.github/scripts/test-summary.sh
+
       - name: Upload test reports
         if: always()
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary

- Adds a test summary step to the integration tests workflow that renders a per-module results table directly in the GitHub Actions job summary
- Parses failsafe XML reports and shows tests, passed, failed, errors, skipped, and time per module with a total row
- Lists individual failed test methods when there are failures
- Script is in `.github/scripts/test-summary.sh` for readability

## Test plan

- [ ] Run the integration tests workflow and verify the summary table appears in the job summary page
- [ ] Verify failed tests are listed when a test fails

## Summary by Sourcery

Add a GitHub Actions job step that publishes a test results summary for integration tests into the job summary.

New Features:
- Generate a per-module test results table in the GitHub Actions job summary for integration tests, including totals.
- List individual failed test methods in the job summary when integration tests fail.

CI:
- Extend the integration-tests workflow with a post-test summary step that parses failsafe XML reports via a dedicated script.