### PR TITLE
fix: enable separate gRPC server in process managers

### DIFF
--- a/test-common/src/main/java/ai/wanaku/test/managers/HttpCapabilityManager.java
+++ b/test-common/src/main/java/ai/wanaku/test/managers/HttpCapabilityManager.java
@@ -46,7 +46,8 @@ public class HttpCapabilityManager extends ProcessManager {
                 target.routerGrpcPort());
 
         // Configure Quarkus properties
-        addSystemProperty("quarkus.http.port", "0"); // Disable HTTP, only gRPC
+        addSystemProperty("quarkus.http.port", "0");
+        addSystemProperty("quarkus.grpc.server.use-separate-server", "true");
         addSystemProperty("quarkus.grpc.server.port", String.valueOf(grpcPort));
 
         // Configure Router connection for capability registration (HTTP REST API)

--- a/test-common/src/main/java/ai/wanaku/test/managers/ResourceProviderManager.java
+++ b/test-common/src/main/java/ai/wanaku/test/managers/ResourceProviderManager.java
@@ -45,6 +45,7 @@ public class ResourceProviderManager extends ProcessManager {
                 target.routerGrpcPort());
 
         addSystemProperty("quarkus.http.port", "0");
+        addSystemProperty("quarkus.grpc.server.use-separate-server", "true");
         addSystemProperty("quarkus.grpc.server.port", String.valueOf(grpcPort));
 
         String registrationUri = target.registrationUri();

--- a/test-common/src/main/java/ai/wanaku/test/managers/RouterManager.java
+++ b/test-common/src/main/java/ai/wanaku/test/managers/RouterManager.java
@@ -45,6 +45,7 @@ public class RouterManager extends ProcessManager {
 
         // Configure Quarkus properties
         addSystemProperty("quarkus.http.port", String.valueOf(httpPort));
+        addSystemProperty("quarkus.grpc.server.use-separate-server", "true");
         addSystemProperty("quarkus.grpc.server.port", String.valueOf(grpcPort));
 
         Path dataDir = config.getTempDataDir();


### PR DESCRIPTION
## Summary

- Fixes all integration tests timing out after 60 seconds on CI
- Root cause: upstream Quarkus apps set `quarkus.grpc.server.use-separate-server=false`, which makes gRPC share the HTTP port. The test managers allocate a dedicated gRPC port and health-check it, but that port is never opened — causing every health check to timeout.
- Adds `quarkus.grpc.server.use-separate-server=true` as a system property override in `HttpCapabilityManager`, `ResourceProviderManager`, and `RouterManager`

## Test plan

- [ ] Run the integration tests workflow with `version=0.2.0-SNAPSHOT` and verify tests pass

## Summary by Sourcery

Bug Fixes:
- Fix integration tests timing out by aligning Quarkus gRPC server configuration with the dedicated gRPC ports allocated by test managers.