### PR TITLE
fix: add bearer token authentication to RouterClient

### DIFF
--- a/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
@@ -108,15 +108,16 @@ public abstract class BaseIntegrationTest {
 
         // Create RouterClient and McpClient
         if (routerManager != null && routerManager.isRunning()) {
-            routerClient = new RouterClient(routerManager.getBaseUrl());
+            String accessToken = null;
+            if (keycloakManager != null && keycloakManager.isRunning()) {
+                accessToken = keycloakManager.getMcpToken();
+                LOG.debug("Obtained MCP access token with wanaku-mcp-client scope");
+            }
+
+            routerClient = new RouterClient(routerManager.getBaseUrl(), accessToken);
 
             // Create MCP client with authentication token (requires wanaku-mcp-client scope)
             try {
-                String accessToken = null;
-                if (keycloakManager != null && keycloakManager.isRunning()) {
-                    accessToken = keycloakManager.getMcpToken();
-                    LOG.debug("Obtained MCP access token with wanaku-mcp-client scope");
-                }
                 mcpClient = new McpTestClient(routerManager.getBaseUrl(), accessToken);
                 mcpClient.connect();
                 LOG.debug("MCP client connected");

--- a/test-common/src/main/java/ai/wanaku/test/client/RouterClient.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/RouterClient.java
@@ -43,9 +43,15 @@ public class RouterClient {
     private final HttpClient httpClient;
     private final ObjectMapper objectMapper;
     private final String baseUrl;
+    private final String accessToken;
 
     public RouterClient(String baseUrl) {
+        this(baseUrl, null);
+    }
+
+    public RouterClient(String baseUrl, String accessToken) {
         this.baseUrl = baseUrl;
+        this.accessToken = accessToken;
         this.httpClient =
                 HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
         this.objectMapper = new ObjectMapper();
@@ -566,7 +572,12 @@ public class RouterClient {
     }
 
     private HttpRequest.Builder buildRequest(String path) {
-        return HttpRequest.newBuilder().uri(URI.create(baseUrl + path)).timeout(Duration.ofSeconds(30));
+        HttpRequest.Builder builder =
+                HttpRequest.newBuilder().uri(URI.create(baseUrl + path)).timeout(Duration.ofSeconds(30));
+        if (accessToken != null) {
+            builder.header("Authorization", "Bearer " + accessToken);
+        }
+        return builder;
     }
 
     public String getBaseUrl() {


### PR DESCRIPTION
## Summary

- Fixes `Failed to list tools: 302` errors and capability registration timeouts on CI
- Root cause: the Router requires OIDC authentication on `/api/v1/*` endpoints, but `RouterClient` was sending unauthenticated requests
- Adds an optional `accessToken` parameter to `RouterClient` and sends it as a `Bearer` header on all requests
- `BaseIntegrationTest` now passes the MCP token (obtained from Keycloak) when creating the `RouterClient`

## Test plan

- [ ] Run the integration tests workflow and verify the 302 errors are gone
- [ ] Verify capability registration succeeds (`isCapabilityRegistered` no longer times out)

## Summary by Sourcery

Add optional bearer token support to RouterClient and use MCP access token in integration tests to enable authenticated router calls.

Bug Fixes:
- Ensure RouterClient sends authenticated requests to Router when an access token is provided, avoiding 302 responses and capability registration timeouts.

Enhancements:
- Extend RouterClient with an optional access token parameter that is applied as a Bearer Authorization header on all HTTP requests.
- Reuse the MCP access token obtained from Keycloak when constructing both RouterClient and McpTestClient in BaseIntegrationTest.