### PR TITLE
fix: isolate process data directories and set WANAKU_HOME for CLI

### DIFF
--- a/test-common/src/main/java/ai/wanaku/test/client/CLIExecutor.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/CLIExecutor.java
@@ -6,7 +6,9 @@ import java.io.InputStreamReader;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.slf4j.Logger;
@@ -21,10 +23,15 @@ public class CLIExecutor {
     private static final Logger LOG = LoggerFactory.getLogger(CLIExecutor.class);
 
     private final String cliPath;
+    private final Map<String, String> environment = new HashMap<>();
     private Duration timeout = Duration.ofSeconds(30);
 
     public CLIExecutor(String cliPath) {
         this.cliPath = cliPath;
+    }
+
+    public void setEnvironment(String key, String value) {
+        environment.put(key, value);
     }
 
     /**
@@ -32,7 +39,11 @@ public class CLIExecutor {
      */
     public static CLIExecutor createDefault() {
         String cliPath = System.getProperty(WanakuTestConstants.PROP_CLI_PATH, WanakuTestConstants.DEFAULT_CLI_PATH);
-        return new CLIExecutor(cliPath);
+        CLIExecutor executor = new CLIExecutor(cliPath);
+        executor.setEnvironment(
+                "WANAKU_HOME",
+                Path.of("target", "wanaku-cli-home").toAbsolutePath().toString());
+        return executor;
     }
 
     /**
@@ -85,6 +96,9 @@ public class CLIExecutor {
                 }
 
                 pb.directory(effectiveWorkingDir.toFile());
+            }
+            if (!environment.isEmpty()) {
+                pb.environment().putAll(environment);
             }
             Process process = pb.start();
 

--- a/test-common/src/main/java/ai/wanaku/test/managers/ProcessManager.java
+++ b/test-common/src/main/java/ai/wanaku/test/managers/ProcessManager.java
@@ -91,14 +91,14 @@ public abstract class ProcessManager {
 
         state = ProcessState.STARTING;
 
-        // Isolate all Wanaku data to target/ so mvn clean removes it.
+        // Isolate all Wanaku data to a unique temp directory per process instance.
         // Without this, processes write to ~/.wanaku/ which conflicts with
         // local Wanaku usage and causes stale data between runs.
         // Each property is used by different process types:
         //   - infinispan.base-folder: Router (Infinispan .dat files)
         //   - service-home: Capabilities (provisioning .properties files)
         // Unused properties are harmlessly ignored by the receiving process.
-        Path dataDir = Path.of("target", "wanaku-data");
+        Path dataDir = Path.of("target", "wanaku-data", getProcessName() + "-" + System.nanoTime());
         addSystemProperty(
                 "wanaku.persistence.infinispan.base-folder",
                 dataDir.resolve("router").toAbsolutePath().toString());


### PR DESCRIPTION
## Summary

Fixes two issues that prevent integration tests from running reliably against Wanaku 0.2.0-SNAPSHOT:

- **Infinispan lock conflicts**: Multiple Router instances across test classes shared the same `target/wanaku-data/router` directory, causing `Failed acquiring lock` errors. Now each process instance gets a unique data directory (appended with process name + nanoTime).

- **CLI credentials directory**: The `CLIExecutor` now supports environment variables and sets `WANAKU_HOME` by default to `target/wanaku-cli-home`, so the CLI writes credentials to a writable test directory instead of the user's home directory.

### Note on CLI native binary

The Wanaku CLI native binary has `user.home` baked in at GraalVM build time as `/home/runner` (the GitHub Actions build environment). This causes `AccessDeniedException: /home/runner` when running locally on a different machine. The `WANAKU_HOME` env var should override this, but the native image doesn't appear to respect it at runtime. This is a Wanaku CLI bug to be addressed separately.

## Test plan

- [ ] Run integration tests workflow with `version=0.2.0-SNAPSHOT`
- [ ] Verify all three test modules execute (http-capability, resources, camel-integration)
- [ ] Verify no Infinispan lock conflicts between test classes

## Summary by Sourcery

Improve integration test reliability by isolating per-process data directories and configuring the CLI to use a test-local WANAKU_HOME for credentials.

New Features:
- Allow CLIExecutor to configure environment variables and set WANAKU_HOME to a test-local directory by default.

Bug Fixes:
- Isolate Wanaku process data into unique per-process directories to prevent Infinispan lock conflicts and stale data between test runs.