### PR TITLE
ci: run all test modules even when one fails

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -58,7 +58,7 @@ jobs:
           ./artifacts/download.sh "${{ steps.version.outputs.version }}"
 
       - name: Run integration tests
-        run: mvn -B verify --file pom.xml
+        run: mvn -B verify --fail-at-end --file pom.xml
 
       - name: Test summary
         if: always()


### PR DESCRIPTION
## Summary

- Adds `--fail-at-end` to the `mvn verify` command in the integration tests workflow
- Without this flag, Maven stops the reactor after the first module failure, so `resources-tests` and `camel-integration-capability-tests` never execute when `http-capability-tests` has failures
- With `--fail-at-end`, all three modules run to completion before the build reports the aggregated failures

## Test plan

- [ ] Run the integration tests workflow and verify all three modules appear in the test summary table

## Summary by Sourcery

CI:
- Add the Maven --fail-at-end flag to the integration tests workflow so all modules execute even if one fails.