### PR TITLE
Fix #107: share Keycloak and Router across test classes

### DIFF
--- a/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
@@ -1,7 +1,6 @@
 package ai.wanaku.test.base;
 
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Duration;
 import org.awaitility.Awaitility;
@@ -16,24 +15,24 @@ import ai.wanaku.test.managers.HttpCapabilityManager;
 import ai.wanaku.test.managers.KeycloakManager;
 import ai.wanaku.test.managers.RouterManager;
 
-import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.TestInfo;
+import org.junit.jupiter.api.extension.ExtendWith;
 
 /**
  * Abstract base class for Wanaku integration tests.
  * Provides layered lifecycle management:
- * - Suite-scoped: Keycloak, Router (shared across all tests)
+ * - Module-scoped: Keycloak, Router (shared across all test classes via {@link SharedInfrastructureExtension})
  * - Test-scoped: HttpToolService, McpClient (fresh per test)
  */
+@ExtendWith(SharedInfrastructureExtension.class)
 public abstract class BaseIntegrationTest {
 
-    // Dynamic logger - uses actual test class name instead of BaseIntegrationTest
     private static Logger LOG = LoggerFactory.getLogger(BaseIntegrationTest.class);
 
-    // Suite-scoped resources (shared across all tests)
+    // Module-scoped resources (populated by SharedInfrastructureExtension, shared across all test classes)
     protected static TestConfiguration config;
     protected static KeycloakManager keycloakManager;
     protected static RouterManager routerManager;
@@ -46,58 +45,10 @@ public abstract class BaseIntegrationTest {
     protected String testName;
 
     @BeforeAll
-    static void setupSuiteInfrastructure(TestInfo testInfo) throws Exception {
-        // Use actual test class for logging
+    static void setupSuiteInfrastructure(TestInfo testInfo) {
         Class<?> testClass = testInfo.getTestClass().orElse(BaseIntegrationTest.class);
-        String testClassName = testClass.getSimpleName();
         LOG = LoggerFactory.getLogger(testClass);
-        LOG.info("=== Setting up suite infrastructure ===");
-
-        // Create isolated temp directory for this test suite
-        tempDataDir = Files.createTempDirectory("wanaku-test-");
-        LOG.debug("Created temp directory: {}", tempDataDir);
-
-        // Load configuration (finds JARs automatically)
-        TestConfiguration baseConfig = TestConfiguration.fromSystemProperties();
-        config = TestConfiguration.builder()
-                .artifactsDir(baseConfig.getArtifactsDir())
-                .routerJarPath(baseConfig.getRouterJarPath())
-                .httpToolServiceJarPath(baseConfig.getHttpToolServiceJarPath())
-                .fileProviderJarPath(baseConfig.getFileProviderJarPath())
-                .camelCapabilityJarPath(baseConfig.getCamelCapabilityJarPath())
-                .tempDataDir(tempDataDir)
-                .defaultTimeout(baseConfig.getDefaultTimeout())
-                .build();
-
-        LOG.debug("Router JAR: {}", config.getRouterJarPath());
-        LOG.debug("HTTP Capability JAR: {}", config.getHttpToolServiceJarPath());
-
-        // Check if we should skip infrastructure setup (for unit tests of test-common)
-        if (shouldSkipInfrastructure()) {
-            LOG.info("Skipping infrastructure setup (no JARs available)");
-            return;
-        }
-
-        // Start Keycloak
-        keycloakManager = new KeycloakManager();
-        try {
-            keycloakManager.start();
-        } catch (Exception e) {
-            LOG.warn("Keycloak startup failed, Router will run without authentication: {}", e.getMessage());
-        }
-
-        // Start Router
-        if (config.getRouterJarPath() != null
-                && config.getRouterJarPath().toFile().exists()) {
-            routerManager = new RouterManager(config);
-            routerManager.prepare();
-            routerManager.start(testClassName);
-            LOG.info("Router started on port {}", routerManager.getHttpPort());
-        } else {
-            LOG.warn("Router JAR not found at {}, skipping Router startup", config.getRouterJarPath());
-        }
-
-        LOG.info("=== Suite infrastructure ready ===");
+        LOG.info("=== Test class starting: {} (reusing shared infrastructure) ===", testClass.getSimpleName());
     }
 
     @BeforeEach
@@ -192,75 +143,6 @@ public abstract class BaseIntegrationTest {
         }
 
         LOG.debug("Test teardown complete: {}", testName);
-    }
-
-    @AfterAll
-    static void teardownSuiteInfrastructure() {
-        LOG.info("=== Tearing down suite infrastructure ===");
-
-        // Stop Router
-        if (routerManager != null) {
-            routerManager.stop();
-            routerManager = null;
-        }
-
-        // Stop Keycloak
-        if (keycloakManager != null) {
-            keycloakManager.stop();
-            keycloakManager = null;
-        }
-
-        // Cleanup temp directory
-        if (tempDataDir != null) {
-            try {
-                deleteRecursively(tempDataDir);
-            } catch (IOException e) {
-                LOG.warn("Failed to cleanup temp directory: {}", e.getMessage());
-            }
-        }
-
-        LOG.info("=== Suite infrastructure teardown complete ===");
-    }
-
-    /**
-     * Checks if infrastructure setup should be skipped.
-     * Override this in subclasses for different behavior.
-     */
-    protected static boolean shouldSkipInfrastructure() {
-        Path artifactsDir = Path.of(System.getProperty("wanaku.test.artifacts.dir", "artifacts"));
-        return !Files.exists(artifactsDir) || !hasJars(artifactsDir);
-    }
-
-    private static boolean hasJars(Path dir) {
-        try {
-            return Files.list(dir).anyMatch(p -> {
-                // Check for standalone JAR files
-                if (p.toString().endsWith(".jar")) {
-                    return true;
-                }
-                // Check for Quarkus app directories containing quarkus-run.jar
-                if (Files.isDirectory(p)) {
-                    Path quarkusRunJar = p.resolve("quarkus-run.jar");
-                    return Files.exists(quarkusRunJar);
-                }
-                return false;
-            });
-        } catch (IOException e) {
-            return false;
-        }
-    }
-
-    private static void deleteRecursively(Path path) throws IOException {
-        if (Files.isDirectory(path)) {
-            Files.list(path).forEach(p -> {
-                try {
-                    deleteRecursively(p);
-                } catch (IOException e) {
-                    LOG.warn("Failed to delete: {}", p);
-                }
-            });
-        }
-        Files.deleteIfExists(path);
     }
 
     /**

--- a/test-common/src/main/java/ai/wanaku/test/base/SharedInfrastructure.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/SharedInfrastructure.java
@@ -1,0 +1,148 @@
+package ai.wanaku.test.base;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ai.wanaku.test.config.TestConfiguration;
+import ai.wanaku.test.managers.KeycloakManager;
+import ai.wanaku.test.managers.RouterManager;
+
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * Holds shared infrastructure (Keycloak + Router) that is started once per JVM
+ * and reused across all test classes within a Maven module.
+ * Registered in JUnit 5's global store so {@code close()} runs at JVM shutdown.
+ */
+public class SharedInfrastructure implements ExtensionContext.Store.CloseableResource {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SharedInfrastructure.class);
+
+    private TestConfiguration config;
+    private KeycloakManager keycloakManager;
+    private RouterManager routerManager;
+    private Path tempDataDir;
+
+    SharedInfrastructure() {}
+
+    void start() throws Exception {
+        LOG.info("=== Starting shared infrastructure (once per module) ===");
+
+        tempDataDir = Files.createTempDirectory("wanaku-test-");
+        LOG.debug("Created shared temp directory: {}", tempDataDir);
+
+        TestConfiguration baseConfig = TestConfiguration.fromSystemProperties();
+        config = TestConfiguration.builder()
+                .artifactsDir(baseConfig.getArtifactsDir())
+                .routerJarPath(baseConfig.getRouterJarPath())
+                .httpToolServiceJarPath(baseConfig.getHttpToolServiceJarPath())
+                .fileProviderJarPath(baseConfig.getFileProviderJarPath())
+                .camelCapabilityJarPath(baseConfig.getCamelCapabilityJarPath())
+                .tempDataDir(tempDataDir)
+                .defaultTimeout(baseConfig.getDefaultTimeout())
+                .build();
+
+        LOG.debug("Router JAR: {}", config.getRouterJarPath());
+        LOG.debug("HTTP Capability JAR: {}", config.getHttpToolServiceJarPath());
+
+        if (shouldSkipInfrastructure()) {
+            LOG.info("Skipping infrastructure setup (no JARs available)");
+            return;
+        }
+
+        keycloakManager = new KeycloakManager();
+        try {
+            keycloakManager.start();
+        } catch (Exception e) {
+            LOG.warn("Keycloak startup failed, Router will run without authentication: {}", e.getMessage());
+        }
+
+        if (config.getRouterJarPath() != null
+                && config.getRouterJarPath().toFile().exists()) {
+            routerManager = new RouterManager(config);
+            routerManager.prepare();
+            routerManager.start("shared");
+            LOG.info("Router started on port {}", routerManager.getHttpPort());
+        } else {
+            LOG.warn("Router JAR not found at {}, skipping Router startup", config.getRouterJarPath());
+        }
+
+        LOG.info("=== Shared infrastructure ready ===");
+    }
+
+    @Override
+    public void close() {
+        LOG.info("=== Tearing down shared infrastructure ===");
+
+        if (routerManager != null) {
+            routerManager.stop();
+        }
+
+        if (keycloakManager != null) {
+            keycloakManager.stop();
+        }
+
+        if (tempDataDir != null) {
+            try {
+                deleteRecursively(tempDataDir);
+            } catch (IOException e) {
+                LOG.warn("Failed to cleanup shared temp directory: {}", e.getMessage());
+            }
+        }
+
+        LOG.info("=== Shared infrastructure teardown complete ===");
+    }
+
+    public TestConfiguration getConfig() {
+        return config;
+    }
+
+    public KeycloakManager getKeycloakManager() {
+        return keycloakManager;
+    }
+
+    public RouterManager getRouterManager() {
+        return routerManager;
+    }
+
+    public Path getTempDataDir() {
+        return tempDataDir;
+    }
+
+    private boolean shouldSkipInfrastructure() {
+        Path artifactsDir = Path.of(System.getProperty("wanaku.test.artifacts.dir", "artifacts"));
+        return !Files.exists(artifactsDir) || !hasJars(artifactsDir);
+    }
+
+    private boolean hasJars(Path dir) {
+        try {
+            return Files.list(dir).anyMatch(p -> {
+                if (p.toString().endsWith(".jar")) {
+                    return true;
+                }
+                if (Files.isDirectory(p)) {
+                    Path quarkusRunJar = p.resolve("quarkus-run.jar");
+                    return Files.exists(quarkusRunJar);
+                }
+                return false;
+            });
+        } catch (IOException e) {
+            return false;
+        }
+    }
+
+    private void deleteRecursively(Path path) throws IOException {
+        if (Files.isDirectory(path)) {
+            Files.list(path).forEach(p -> {
+                try {
+                    deleteRecursively(p);
+                } catch (IOException e) {
+                    LOG.warn("Failed to delete: {}", p);
+                }
+            });
+        }
+        Files.deleteIfExists(path);
+    }
+}

--- a/test-common/src/main/java/ai/wanaku/test/base/SharedInfrastructureExtension.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/SharedInfrastructureExtension.java
@@ -1,0 +1,40 @@
+package ai.wanaku.test.base;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+
+/**
+ * JUnit 5 extension that starts shared infrastructure (Keycloak + Router) once per JVM.
+ * Uses the global extension store so the infrastructure is created exactly once and
+ * cleaned up via {@link SharedInfrastructure#close()} when the store is closed.
+ */
+public class SharedInfrastructureExtension implements BeforeAllCallback {
+
+    private static final Logger LOG = LoggerFactory.getLogger(SharedInfrastructureExtension.class);
+
+    @Override
+    public void beforeAll(ExtensionContext context) throws Exception {
+        SharedInfrastructure infra = context.getRoot()
+                .getStore(ExtensionContext.Namespace.GLOBAL)
+                .getOrComputeIfAbsent(
+                        SharedInfrastructure.class,
+                        key -> {
+                            SharedInfrastructure si = new SharedInfrastructure();
+                            try {
+                                si.start();
+                            } catch (Exception e) {
+                                throw new RuntimeException("Failed to start shared infrastructure", e);
+                            }
+                            return si;
+                        },
+                        SharedInfrastructure.class);
+
+        BaseIntegrationTest.config = infra.getConfig();
+        BaseIntegrationTest.keycloakManager = infra.getKeycloakManager();
+        BaseIntegrationTest.routerManager = infra.getRouterManager();
+        BaseIntegrationTest.tempDataDir = infra.getTempDataDir();
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces `SharedInfrastructure` and `SharedInfrastructureExtension` to start Keycloak + Router once per module via JUnit 5's global extension store (`ExtensionContext.Store.GLOBAL`)
- Removes per-class `@BeforeAll`/`@AfterAll` infrastructure startup/shutdown from `BaseIntegrationTest`
- Shutdown handled automatically via `CloseableResource` when the JVM exits

## Test plan

- [x] `mvn -DskipTests package` compiles cleanly
- [x] `mvn verify` on http-capability-tests: 18 tests run, same 3 pre-existing CLI failures, no regressions
- [x] Timing comparison: HTTP capability module goes from 4:42 to 2:38 (44% faster)
- [ ] CI verifies all modules pass (resource/camel test failures are pre-existing, unrelated to this change)

Closes #107

## Summary by Sourcery

Share Keycloak and Router test infrastructure across integration test classes using a JUnit 5 global extension and refactor BaseIntegrationTest to reuse this shared setup.

New Features:
- Introduce a JUnit 5 global extension to manage shared Keycloak and Router infrastructure across integration test classes within a module

Enhancements:
- Refactor BaseIntegrationTest to depend on shared, module-scoped infrastructure instead of per-class setup and teardown, improving test execution time