### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -24,10 +24,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
         with:
           java-version: '21'
           distribution: 'temurin'
@@ -66,7 +66,7 @@ jobs:
 
       - name: Upload test reports
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: integration-test-reports
           path: |

--- a/.github/workflows/main-build.yml
+++ b/.github/workflows/main-build.yml
@@ -21,9 +21,9 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Set up JDK 21
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
       with:
         java-version: '21'
         distribution: 'temurin'

--- a/.github/workflows/pr-builds.yml
+++ b/.github/workflows/pr-builds.yml
@@ -20,9 +20,9 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v7
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
     - name: Set up JDK 21
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0
       with:
         java-version: '21'
         distribution: 'temurin'


### PR DESCRIPTION
## Summary

- Pinned all GitHub Actions by commit SHA and upgraded to latest releases across 3 workflow files

| Action | Old | New |
|--------|-----|-----|
| actions/checkout | v6 / v7 (unpinned) | v7.0.0 (SHA-pinned) |
| actions/setup-java | v5 (unpinned) | v5.5.0 (SHA-pinned) |
| actions/upload-artifact | v4 (unpinned) | v7.0.1 (SHA-pinned) |

## Test plan

- [ ] Verify PR build passes with the updated actions
- [ ] Verify integration-tests workflow runs correctly with updated actions

## Summary by Sourcery

Pin and upgrade core GitHub Actions used in build and integration workflows to current, SHA-pinned versions.

Build:
- Update workflow configurations to use the latest versions of actions/checkout, actions/setup-java, and actions/upload-artifact pinned by commit SHA across main, PR, and integration test builds.

CI:
- Refresh CI workflows to rely on up-to-date, SHA-pinned GitHub Actions for checkout, Java setup, and artifact upload to improve reliability and security.