### PR TITLE
Fix #120: configure CLI binary path in CI workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -57,8 +57,27 @@ jobs:
           chmod +x ./artifacts/download.sh
           ./artifacts/download.sh "${{ steps.version.outputs.version }}"
 
+      - name: Resolve CLI path
+        id: cli
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          CLI_DIR=$(ls -d artifacts/wanaku-cli-${VERSION}* 2>/dev/null | head -1)
+          if [ -z "$CLI_DIR" ]; then
+            echo "::warning::CLI directory not found for version ${VERSION}"
+            echo "path=" >> "$GITHUB_OUTPUT"
+          else
+            CLI_PATH="${CLI_DIR}/bin/wanaku"
+            chmod +x "${CLI_PATH}" 2>/dev/null || true
+            echo "path=$(pwd)/${CLI_PATH}" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Run integration tests
-        run: mvn -B verify --fail-at-end --file pom.xml
+        run: |
+          CLI_OPTS=""
+          if [ -n "${{ steps.cli.outputs.path }}" ]; then
+            CLI_OPTS="-Dwanaku.test.cli.path=${{ steps.cli.outputs.path }}"
+          fi
+          mvn -B verify --fail-at-end --file pom.xml ${CLI_OPTS}
 
       - name: Test summary
         if: always()


### PR DESCRIPTION
## Summary

- Add a "Resolve CLI path" step that locates the extracted CLI binary after artifact download
- Pass the resolved path to Maven via `-Dwanaku.test.cli.path` so `HttpToolCliITCase` can find the binary
- Handles both SNAPSHOT (platform-suffixed directory) and release (plain directory) naming conventions
- Emits a warning if the CLI directory isn't found instead of failing silently

## Test plan

- [ ] Trigger CI workflow with `version: 0.2.0-SNAPSHOT` — `HttpToolCliITCase` should no longer fail with "Cannot run program wanaku"
- [ ] Verify the CLI path is correctly resolved in the CI log output

## Summary by Sourcery

Configure the CI integration test workflow to resolve and pass the Wanaku CLI binary path to Maven so CLI-based tests can run reliably.

Build:
- Add a step in the integration-tests workflow to detect the Wanaku CLI directory for the current version and expose the resolved binary path as a job output.
- Update the Maven integration test invocation to conditionally include the resolved CLI path system property used by CLI integration tests.