### PR TITLE
ci: support running integration tests from a specific branch

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -25,6 +25,8 @@ jobs:
     timeout-minutes: 45
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.client_payload.branch || github.ref }}
 
       - name: Set up JDK 21
         uses: actions/setup-java@0f481fcb613427c0f801b606911222b5b6f3083a # v5.5.0


### PR DESCRIPTION
## Summary

- Allow `repository_dispatch` callers to specify a `branch` in the `client_payload` so integration tests check out that branch of wanaku-tests instead of always using the default branch.
- For `workflow_dispatch` and `schedule` triggers, behavior is unchanged (`github.ref` resolves to the selected/default branch).

## Test plan

- [ ] Trigger via `workflow_dispatch` on `main` — should behave as before
- [ ] Trigger via `repository_dispatch` with `{"branch": "some-branch", "version": "0.3.0-SNAPSHOT"}` — should check out `some-branch`
- [ ] Trigger via `repository_dispatch` without `branch` in payload — should fall back to `github.ref`

## Summary by Sourcery

Enhancements:
- Allow integration test workflow to check out a branch specified in repository_dispatch client_payload, falling back to github.ref when not provided.