### PR TITLE
Fix integration test suite stability and CI artifact collection

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -92,5 +92,6 @@ jobs:
           name: integration-test-reports
           path: |
             **/target/failsafe-reports/
+            **/target/logs/
           retention-days: 14
           if-no-files-found: ignore


### PR DESCRIPTION
## Summary

- Replace external httpbin.org dependency with a local container for HTTP POST tests
- Add retry logic and increase timeouts for Camel Integration Capability startup
- Fix health probe wait logic for MULTI_CAPABILITY endpoint
- Resolve CLI auth and DataStore dependency issues
- Upload process logs (`target/logs/`) as CI artifacts alongside JUnit reports for easier debugging

## Test plan

- [ ] Integration tests pass in CI
- [ ] Process logs appear in the uploaded CI artifacts

## Summary by Sourcery

Stabilize integration tests and CI diagnostics by hardening capability startup, decoupling HTTP tests from external services, and improving CLI auth and DataStore handling.

Enhancements:
- Introduce reusable retry helper for MCP tool invocations and expand Awaitility timeouts for Camel integration capabilities and PostgreSQL error-path tests.
- Default Camel capabilities to always receive a dependencies reference, creating an empty deps file when none is provided, and ensure DataStore-based tests upload matching placeholder dependencies.
- Replace external httpbin.org usage with a local go-httpbin Testcontainers instance, updating HTTP capability tests accordingly.
- Update CLI-based resource and HTTP tool tests to support authenticated execution via Keycloak-issued tokens and to use shared CLIExecutor instances.
- Ensure file provider tests construct RouterClient instances with optional access tokens from Keycloak when available.

CI:
- Extend the integration test GitHub Actions workflow to collect process logs from target/logs/ as CI artifacts alongside failsafe reports for easier debugging.

Tests:
- Adjust various Camel, HTTP, and resource integration tests to use the new retry and auth mechanisms and to align expectations with the local httpbin container behavior.