### PR TITLE
chore: upgrade Quarkus from 3.27.2 to 3.33.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- Dependency versions (aligned with Wanaku) -->
-        <quarkus.version>3.27.2</quarkus.version>
+        <quarkus.version>3.33.2</quarkus.version>
         <quarkus-mcp.version>1.10.2</quarkus-mcp.version>
         <junit.version>5.10.2</junit.version>
         <testcontainers.version>1.19.7</testcontainers.version>


### PR DESCRIPTION
## Summary
- Upgrades Quarkus platform BOM from 3.27.2 to 3.33.2

## Test plan
- [x] Local build passes (`mvn -DskipTests package`)
- [x] CI Integration Tests triggered with Wanaku 0.2.0-SNAPSHOT: https://github.com/orpiske/wanaku-tests/actions/runs/29577648872