### PR TITLE
Fix #119: fix all CIC test failures for Wanaku 0.2.0-SNAPSHOT

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -17,7 +17,7 @@ on:
 
 env:
   # Update when upstream development version changes
-  DEFAULT_SNAPSHOT_VERSION: '0.3.0-SNAPSHOT'
+  DEFAULT_SNAPSHOT_VERSION: '0.2.0-SNAPSHOT'
 
 jobs:
   integration-tests:

--- a/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelBasicToolITCase.java
+++ b/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelBasicToolITCase.java
@@ -121,7 +121,7 @@ class CamelBasicToolITCase extends CamelCapabilityTestBase {
 
         dataStoreClient.upload("test-routes.camel.yaml", routesContent);
         dataStoreClient.upload("test-rules.yaml", rulesContent);
-        dataStoreClient.upload("empty-deps.txt", "");
+        dataStoreClient.upload("empty-deps.txt", "# no dependencies");
 
         startCapabilityFromDataStore(
                 "ds-tool-svc",

--- a/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelCapabilityTestBase.java
+++ b/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelCapabilityTestBase.java
@@ -218,7 +218,9 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
                 .pollInterval(Duration.ofMillis(500))
                 .until(() -> {
                     if (!manager.isRunning()) {
-                        LOG.warn("CIC '{}' process died before registration completed", serviceName);
+                        throw new IllegalStateException(
+                                "CIC '" + serviceName + "' process exited before registration completed."
+                                        + " Check process logs for details.");
                     }
                     return routerClient.isCapabilityRegistered(serviceName);
                 });
@@ -232,7 +234,9 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
                 .pollInterval(Duration.ofMillis(500))
                 .until(() -> {
                     if (!manager.isRunning()) {
-                        LOG.warn("CIC '{}' process died before tools/resources registered", serviceName);
+                        throw new IllegalStateException(
+                                "CIC '" + serviceName + "' process exited before tools/resources registered."
+                                        + " Check process logs for details.");
                     }
                     boolean hasTools = routerClient.listTools().stream().anyMatch(t -> serviceName.equals(t.getType()));
                     boolean hasResources =

--- a/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelCapabilityTestBase.java
+++ b/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelCapabilityTestBase.java
@@ -218,9 +218,12 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
                 .pollInterval(Duration.ofMillis(500))
                 .until(() -> {
                     if (!manager.isRunning()) {
-                        throw new IllegalStateException(
-                                "CIC '" + serviceName + "' process exited before registration completed."
-                                        + " Check process logs for details.");
+                        String logPath = manager.getLogFile() != null
+                                ? manager.getLogFile().getAbsolutePath()
+                                : "unknown";
+                        throw new IllegalStateException("CIC '" + serviceName + "' process exited (exit code: "
+                                + manager.getExitCode() + ") before registration completed."
+                                + " Log file: " + logPath);
                     }
                     return routerClient.isCapabilityRegistered(serviceName);
                 });
@@ -235,8 +238,7 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
                 .until(() -> {
                     if (!manager.isRunning()) {
                         throw new IllegalStateException(
-                                "CIC '" + serviceName + "' process exited before tools/resources registered."
-                                        + " Check process logs for details.");
+                                "CIC '" + serviceName + "' process exited before tools/resources registered.");
                     }
                     boolean hasTools = routerClient.listTools().stream().anyMatch(t -> serviceName.equals(t.getType()));
                     boolean hasResources =
@@ -275,11 +277,33 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
 
     protected void assertToolCallWithRetry(
             String toolName, Map<String, Object> args, Consumer<ToolResponse> assertions) {
+        java.util.concurrent.atomic.AtomicBoolean loggedOnce = new java.util.concurrent.atomic.AtomicBoolean();
         Awaitility.await()
                 .atMost(Duration.ofSeconds(90))
                 .pollInterval(Duration.ofSeconds(3))
                 .untilAsserted(() -> {
-                    mcpClient.when().toolsCall(toolName, args, assertions).thenAssertResults();
+                    try {
+                        mcpClient.when().toolsCall(toolName, args, assertions).thenAssertResults();
+                    } catch (AssertionError | Exception e) {
+                        if (!loggedOnce.getAndSet(true)) {
+                            LOG.warn("Tool call '{}' failed, listing available MCP tools for diagnostics...", toolName);
+                            try {
+                                mcpClient
+                                        .when()
+                                        .toolsList()
+                                        .withAssert(page -> LOG.info(
+                                                "Available MCP tools: {}",
+                                                page.tools().stream()
+                                                        .map(t -> t.name())
+                                                        .toList()))
+                                        .send()
+                                        .thenAssertResults();
+                            } catch (Exception listErr) {
+                                LOG.warn("Failed to list MCP tools: {}", listErr.getMessage());
+                            }
+                        }
+                        throw e;
+                    }
                 });
     }
 

--- a/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelCapabilityTestBase.java
+++ b/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelCapabilityTestBase.java
@@ -15,6 +15,7 @@ import org.slf4j.LoggerFactory;
 import io.quarkiverse.mcp.server.ToolResponse;
 import ai.wanaku.test.base.BaseIntegrationTest;
 import ai.wanaku.test.client.DataStoreClient;
+import ai.wanaku.test.client.McpTestClient;
 import ai.wanaku.test.config.OidcCredentials;
 import ai.wanaku.test.config.TargetConfiguration;
 import ai.wanaku.test.fixtures.TestFixtures;
@@ -167,25 +168,7 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
         manager.setLogContext("camel-capability", getClass().getSimpleName(), serviceName);
         manager.start(serviceName);
 
-        LOG.debug("Waiting for CIC '{}' to register with Router...", serviceName);
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(90))
-                .pollInterval(Duration.ofMillis(500))
-                .until(() -> routerClient.isCapabilityRegistered(serviceName));
-        LOG.info("CIC '{}' is registered with Router", serviceName);
-
-        // Wait for tools/resources to be registered
-        LOG.debug("Waiting for CIC '{}' tools/resources to appear in Router...", serviceName);
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(90))
-                .pollInterval(Duration.ofMillis(500))
-                .until(() -> {
-                    boolean hasTools = routerClient.listTools().stream().anyMatch(t -> serviceName.equals(t.getType()));
-                    boolean hasResources =
-                            routerClient.listResources().stream().anyMatch(r -> serviceName.equals(r.getType()));
-                    return hasTools || hasResources;
-                });
-        LOG.info("CIC '{}' tools/resources are available", serviceName);
+        waitForCapabilityReady(serviceName, manager);
 
         camelManagers.add(manager);
         return manager;
@@ -221,12 +204,24 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
         manager.setLogContext("camel-capability", getClass().getSimpleName(), serviceName);
         manager.start(serviceName);
 
+        waitForCapabilityReady(serviceName, manager);
+
+        camelManagers.add(manager);
+        return manager;
+    }
+
+    private void waitForCapabilityReady(String serviceName, CamelCapabilityManager manager) {
         // Wait for capability registration
         LOG.debug("Waiting for CIC '{}' to register with Router...", serviceName);
         Awaitility.await()
                 .atMost(Duration.ofSeconds(90))
                 .pollInterval(Duration.ofMillis(500))
-                .until(() -> routerClient.isCapabilityRegistered(serviceName));
+                .until(() -> {
+                    if (!manager.isRunning()) {
+                        LOG.warn("CIC '{}' process died before registration completed", serviceName);
+                    }
+                    return routerClient.isCapabilityRegistered(serviceName);
+                });
         LOG.info("CIC '{}' is registered with Router", serviceName);
 
         // Wait for tools/resources to be registered (CIC registers them asynchronously
@@ -236,6 +231,9 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
                 .atMost(Duration.ofSeconds(90))
                 .pollInterval(Duration.ofMillis(500))
                 .until(() -> {
+                    if (!manager.isRunning()) {
+                        LOG.warn("CIC '{}' process died before tools/resources registered", serviceName);
+                    }
                     boolean hasTools = routerClient.listTools().stream().anyMatch(t -> serviceName.equals(t.getType()));
                     boolean hasResources =
                             routerClient.listResources().stream().anyMatch(r -> serviceName.equals(r.getType()));
@@ -243,8 +241,32 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
                 });
         LOG.info("CIC '{}' tools/resources are available", serviceName);
 
-        camelManagers.add(manager);
-        return manager;
+        // Reconnect MCP client so it picks up newly registered tools/resources.
+        // The MCP Streamable HTTP transport may cache tool metadata from the
+        // initial connection; a fresh session ensures the client sees the latest state.
+        reconnectMcpClient();
+    }
+
+    private void reconnectMcpClient() {
+        if (mcpClient == null) {
+            return;
+        }
+        try {
+            mcpClient.disconnect();
+        } catch (Exception e) {
+            LOG.debug("MCP disconnect during reconnect: {}", e.getMessage());
+        }
+        try {
+            String accessToken = null;
+            if (keycloakManager != null && keycloakManager.isRunning()) {
+                accessToken = keycloakManager.getMcpToken();
+            }
+            mcpClient = new McpTestClient(routerManager.getBaseUrl(), accessToken);
+            mcpClient.connect();
+            LOG.debug("MCP client reconnected");
+        } catch (Exception e) {
+            LOG.warn("Failed to reconnect MCP client: {}", e.getMessage());
+        }
     }
 
     protected void assertToolCallWithRetry(
@@ -255,6 +277,13 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
                 .untilAsserted(() -> {
                     mcpClient.when().toolsCall(toolName, args, assertions).thenAssertResults();
                 });
+    }
+
+    protected void assertResourceReadWithRetry(String resourceUri, Runnable assertion) {
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(90))
+                .pollInterval(Duration.ofSeconds(3))
+                .untilAsserted(assertion::run);
     }
 
     /**

--- a/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelCapabilityTestBase.java
+++ b/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelCapabilityTestBase.java
@@ -8,6 +8,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
@@ -237,8 +238,12 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
                 .pollInterval(Duration.ofMillis(500))
                 .until(() -> {
                     if (!manager.isRunning()) {
-                        throw new IllegalStateException(
-                                "CIC '" + serviceName + "' process exited before tools/resources registered.");
+                        String logPath = manager.getLogFile() != null
+                                ? manager.getLogFile().getAbsolutePath()
+                                : "unknown";
+                        throw new IllegalStateException("CIC '" + serviceName + "' process exited (exit code: "
+                                + manager.getExitCode() + ") before tools/resources registered."
+                                + " Log file: " + logPath);
                     }
                     boolean hasTools = routerClient.listTools().stream().anyMatch(t -> serviceName.equals(t.getType()));
                     boolean hasResources =
@@ -262,22 +267,19 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
         } catch (Exception e) {
             LOG.debug("MCP disconnect during reconnect: {}", e.getMessage());
         }
-        try {
-            String accessToken = null;
-            if (keycloakManager != null && keycloakManager.isRunning()) {
-                accessToken = keycloakManager.getMcpToken();
-            }
-            mcpClient = new McpTestClient(routerManager.getBaseUrl(), accessToken);
-            mcpClient.connect();
-            LOG.debug("MCP client reconnected");
-        } catch (Exception e) {
-            LOG.warn("Failed to reconnect MCP client: {}", e.getMessage());
+        mcpClient = null;
+        String accessToken = null;
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            accessToken = keycloakManager.getMcpToken();
         }
+        mcpClient = new McpTestClient(routerManager.getBaseUrl(), accessToken);
+        mcpClient.connect();
+        LOG.debug("MCP client reconnected");
     }
 
     protected void assertToolCallWithRetry(
             String toolName, Map<String, Object> args, Consumer<ToolResponse> assertions) {
-        java.util.concurrent.atomic.AtomicBoolean loggedOnce = new java.util.concurrent.atomic.AtomicBoolean();
+        AtomicBoolean loggedOnce = new AtomicBoolean();
         Awaitility.await()
                 .atMost(Duration.ofSeconds(90))
                 .pollInterval(Duration.ofSeconds(3))
@@ -307,7 +309,7 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
                 });
     }
 
-    protected void assertResourceReadWithRetry(String resourceUri, Runnable assertion) {
+    protected void assertResourceReadWithRetry(Runnable assertion) {
         Awaitility.await()
                 .atMost(Duration.ofSeconds(90))
                 .pollInterval(Duration.ofSeconds(3))

--- a/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelFileResourceITCase.java
+++ b/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelFileResourceITCase.java
@@ -76,16 +76,19 @@ class CamelFileResourceITCase extends CamelCapabilityTestBase {
         Path testFile = createTestFile("test-read.txt", "Hello Wanaku from CIC resource");
         startFileResourceCapability(SERVICE_NAME, RESOURCE_NAME, testFile);
 
-        mcpClient
-                .when()
-                .resourcesRead(RESOURCE_URI)
-                .withAssert(response -> {
-                    LOG.debug("=== MCP resourcesRead response [test-file-resource]: {}", response.contents());
-                    assertThat(response.contents()).isNotEmpty();
-                    assertThat(response.contents().get(0).asText().text()).contains("Hello Wanaku from CIC resource");
-                })
-                .send()
-                .thenAssertResults();
+        assertResourceReadWithRetry(RESOURCE_URI, () -> {
+            mcpClient
+                    .when()
+                    .resourcesRead(RESOURCE_URI)
+                    .withAssert(response -> {
+                        LOG.debug("=== MCP resourcesRead response [test-file-resource]: {}", response.contents());
+                        assertThat(response.contents()).isNotEmpty();
+                        assertThat(response.contents().get(0).asText().text())
+                                .contains("Hello Wanaku from CIC resource");
+                    })
+                    .send()
+                    .thenAssertResults();
+        });
     }
 
     @DisplayName("Read resource pointing to non-existent file and verify error response")
@@ -128,28 +131,32 @@ class CamelFileResourceITCase extends CamelCapabilityTestBase {
         startFileResourceCapability("switch-svc-a", "switch-res-a", fileA);
         startFileResourceCapability("switch-svc-b", "switch-res-b", fileB);
 
-        // First read
-        mcpClient
-                .when()
-                .resourcesRead("switch-svc-a://switch-res-a")
-                .withAssert(r -> {
-                    LOG.debug("=== MCP resourcesRead response [1st switch-res-a]: {}", r.contents());
-                    assertThat(r.contents()).isNotEmpty();
-                    assertThat(r.contents().get(0).asText().text()).contains("Alpha content");
-                })
-                .send()
-                .thenAssertResults();
+        // First read (with retry — CIC routes may not be fully started yet)
+        assertResourceReadWithRetry("switch-svc-a://switch-res-a", () -> {
+            mcpClient
+                    .when()
+                    .resourcesRead("switch-svc-a://switch-res-a")
+                    .withAssert(r -> {
+                        LOG.debug("=== MCP resourcesRead response [1st switch-res-a]: {}", r.contents());
+                        assertThat(r.contents()).isNotEmpty();
+                        assertThat(r.contents().get(0).asText().text()).contains("Alpha content");
+                    })
+                    .send()
+                    .thenAssertResults();
+        });
 
-        mcpClient
-                .when()
-                .resourcesRead("switch-svc-b://switch-res-b")
-                .withAssert(r -> {
-                    LOG.debug("=== MCP resourcesRead response [1st switch-res-b]: {}", r.contents());
-                    assertThat(r.contents()).isNotEmpty();
-                    assertThat(r.contents().get(0).asText().text()).contains("Beta content");
-                })
-                .send()
-                .thenAssertResults();
+        assertResourceReadWithRetry("switch-svc-b://switch-res-b", () -> {
+            mcpClient
+                    .when()
+                    .resourcesRead("switch-svc-b://switch-res-b")
+                    .withAssert(r -> {
+                        LOG.debug("=== MCP resourcesRead response [1st switch-res-b]: {}", r.contents());
+                        assertThat(r.contents()).isNotEmpty();
+                        assertThat(r.contents().get(0).asText().text()).contains("Beta content");
+                    })
+                    .send()
+                    .thenAssertResults();
+        });
 
         // Re-read — must return original content, not stale or empty
         mcpClient
@@ -212,16 +219,18 @@ class CamelFileResourceITCase extends CamelCapabilityTestBase {
                 "datastore://test-res-rules.yaml",
                 "datastore://empty-deps.txt");
 
-        mcpClient
-                .when()
-                .resourcesRead(dsResourceUri)
-                .withAssert(response -> {
-                    LOG.debug("=== MCP resourcesRead response [DataStore resource]: {}", response.contents());
-                    assertThat(response.contents()).isNotEmpty();
-                    assertThat(response.contents().get(0).asText().text()).contains("DataStore resource content");
-                })
-                .send()
-                .thenAssertResults();
+        assertResourceReadWithRetry(dsResourceUri, () -> {
+            mcpClient
+                    .when()
+                    .resourcesRead(dsResourceUri)
+                    .withAssert(response -> {
+                        LOG.debug("=== MCP resourcesRead response [DataStore resource]: {}", response.contents());
+                        assertThat(response.contents()).isNotEmpty();
+                        assertThat(response.contents().get(0).asText().text()).contains("DataStore resource content");
+                    })
+                    .send()
+                    .thenAssertResults();
+        });
     }
 
     // -- Helpers --

--- a/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelFileResourceITCase.java
+++ b/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelFileResourceITCase.java
@@ -208,7 +208,7 @@ class CamelFileResourceITCase extends CamelCapabilityTestBase {
 
         dataStoreClient.upload("test-res-routes.camel.yaml", routesContent);
         dataStoreClient.upload("test-res-rules.yaml", rulesContent);
-        dataStoreClient.upload("empty-deps.txt", "");
+        dataStoreClient.upload("empty-deps.txt", "# no dependencies");
 
         String dsServiceName = "ds-resource-svc";
         String dsResourceUri = dsServiceName + "://" + RESOURCE_NAME;

--- a/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelFileResourceITCase.java
+++ b/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelFileResourceITCase.java
@@ -76,7 +76,7 @@ class CamelFileResourceITCase extends CamelCapabilityTestBase {
         Path testFile = createTestFile("test-read.txt", "Hello Wanaku from CIC resource");
         startFileResourceCapability(SERVICE_NAME, RESOURCE_NAME, testFile);
 
-        assertResourceReadWithRetry(RESOURCE_URI, () -> {
+        assertResourceReadWithRetry(() -> {
             mcpClient
                     .when()
                     .resourcesRead(RESOURCE_URI)
@@ -132,7 +132,7 @@ class CamelFileResourceITCase extends CamelCapabilityTestBase {
         startFileResourceCapability("switch-svc-b", "switch-res-b", fileB);
 
         // First read (with retry — CIC routes may not be fully started yet)
-        assertResourceReadWithRetry("switch-svc-a://switch-res-a", () -> {
+        assertResourceReadWithRetry(() -> {
             mcpClient
                     .when()
                     .resourcesRead("switch-svc-a://switch-res-a")
@@ -145,7 +145,7 @@ class CamelFileResourceITCase extends CamelCapabilityTestBase {
                     .thenAssertResults();
         });
 
-        assertResourceReadWithRetry("switch-svc-b://switch-res-b", () -> {
+        assertResourceReadWithRetry(() -> {
             mcpClient
                     .when()
                     .resourcesRead("switch-svc-b://switch-res-b")
@@ -219,7 +219,7 @@ class CamelFileResourceITCase extends CamelCapabilityTestBase {
                 "datastore://test-res-rules.yaml",
                 "datastore://empty-deps.txt");
 
-        assertResourceReadWithRetry(dsResourceUri, () -> {
+        assertResourceReadWithRetry(() -> {
             mcpClient
                     .when()
                     .resourcesRead(dsResourceUri)

--- a/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelPostgresToolITCase.java
+++ b/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelPostgresToolITCase.java
@@ -1,9 +1,7 @@
 package ai.wanaku.test.camel;
 
 import java.io.InputStream;
-import java.time.Duration;
 import java.util.Map;
-import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.quarkus.test.junit.QuarkusTest;
@@ -87,29 +85,16 @@ class CamelPostgresToolITCase extends CamelCapabilityTestBase {
     void shouldHandleDatabaseError() throws Exception {
         startPostgresCapability();
 
-        Awaitility.await()
-                .atMost(Duration.ofSeconds(90))
-                .pollInterval(Duration.ofSeconds(3))
-                .untilAsserted(() -> {
-                    mcpClient
-                            .when()
-                            .toolsCall("query-db")
-                            .withArguments(Map.of("query", "SELECT * FROM nonexistent_table"))
-                            .withErrorAssert(error -> {
-                                LOG.debug(
-                                        "=== MCP toolsCall error [query-db-error]: code={}, message={}",
-                                        error.code(),
-                                        error.message());
-                                assertThat(error.code())
-                                        .as("Invalid SQL should return internal error code")
-                                        .isEqualTo(-32603);
-                                assertThat(error.message())
-                                        .as("Error message should indicate internal error")
-                                        .containsIgnoringCase("Internal error");
-                            })
-                            .send()
-                            .thenAssertResults();
-                });
+        assertToolCallWithRetry("query-db", Map.of("query", "SELECT * FROM nonexistent_table"), response -> {
+            LOG.debug("=== MCP toolsCall response [query-db-error]: {}", response.content());
+            assertThat(response.isError())
+                    .as("Invalid SQL should return an error response")
+                    .isTrue();
+            assertThat(response.content()).isNotEmpty();
+            assertThat(response.content().get(0).asText().text())
+                    .as("Error response should mention the invocation failure")
+                    .containsIgnoringCase("Unable to invoke tool");
+        });
     }
 
     @DisplayName("Load PostgreSQL tool config from Data Store and verify it works")

--- a/camel-integration-capability-tests/src/test/resources/fixtures/postgres-tool/dependencies.txt
+++ b/camel-integration-capability-tests/src/test/resources/fixtures/postgres-tool/dependencies.txt
@@ -1,1 +1,2 @@
 org.postgresql:postgresql:42.7.4
+org.apache.camel:camel-jdbc:4.12.0

--- a/test-common/src/main/java/ai/wanaku/test/managers/ProcessManager.java
+++ b/test-common/src/main/java/ai/wanaku/test/managers/ProcessManager.java
@@ -203,6 +203,23 @@ public abstract class ProcessManager {
     }
 
     /**
+     * Gets the log file for this process.
+     */
+    public File getLogFile() {
+        return logFile;
+    }
+
+    /**
+     * Gets the process exit code, or -1 if the process is still running or hasn't started.
+     */
+    public int getExitCode() {
+        if (process == null || process.isAlive()) {
+            return -1;
+        }
+        return process.exitValue();
+    }
+
+    /**
      * Creates a log file for this process.
      * Override in subclasses for custom log file locations.
      *


### PR DESCRIPTION
## Summary

- Fix DEFAULT_SNAPSHOT_VERSION from 0.3.0-SNAPSHOT to 0.2.0-SNAPSHOT (fixes #119)
- Add `org.apache.camel:camel-jdbc:4.12.0` to postgres-tool dependencies — CIC was crashing because the JDBC Camel component was missing from the classpath
- Fix empty DataStore dependency uploads — uploading `""` produces entries with "no data" that the CIC rejects; now uploads `"# no dependencies"`
- Add retry logic for MCP resource reads (`assertResourceReadWithRetry`) — CIC routes may not be fully started when the first read arrives
- Update `shouldHandleDatabaseError` assertion to match actual Wanaku error format (ToolResponse with `isError=true`, not JSON-RPC error)
- Reconnect MCP client after CIC tools/resources registration
- Fail fast when CIC process dies during registration waits
- Add diagnostic logging: exit code, log file path, and MCP tools list on tool call failure
- Add `getLogFile()` and `getExitCode()` to ProcessManager
- Extract common `waitForCapabilityReady` method to deduplicate startCapabilityFromDir and startCapabilityFromDataStore

## Test Results

| Before | After |
|--------|-------|
| Tests run: 16, Errors: 7 | Tests run: 16, Errors: 0 |
| BUILD FAILURE | BUILD SUCCESS |

CI run: https://github.com/orpiske/wanaku-tests/actions/runs/29582976796

## Test plan

- [x] All 16 CIC tests pass
- [x] All 18 HTTP Capability tests pass
- [x] All 12 Resource tests pass
- [x] Total: 46 tests, 0 failures, 0 errors

## Summary by Sourcery

Improve robustness and diagnostics of Camel integration capability (CIC) tests and align them with Wanaku 0.2.0-SNAPSHOT behavior.

New Features:
- Add retry helpers for MCP tool calls and resource reads to handle asynchronous CIC startup.
- Automatically reconnect the MCP client after capability tools/resources are registered to ensure fresh metadata.
- Expose log file and exit code information from ProcessManager for use in test diagnostics.

Bug Fixes:
- Update the default snapshot version in CI to 0.2.0-SNAPSHOT to match the tested Wanaku version.
- Prevent CIC failures by ensuring DataStore uploads use a non-empty dependencies file instead of an empty string.
- Adjust the PostgreSQL tool error assertion to match the actual ToolResponse error format instead of a JSON-RPC error.
- Fail fast in capability startup waits when the CIC process exits prematurely, avoiding hanging tests.

Enhancements:
- Extract a shared capability readiness wait helper to deduplicate registration logic across data store and directory-based startups.
- Add diagnostic logging around failed MCP tool calls, including listing available tools for easier debugging.

Build:
- Update the integration-tests workflow environment to use DEFAULT_SNAPSHOT_VERSION 0.2.0-SNAPSHOT.

Tests:
- Strengthen CIC tests with retries and improved diagnostics to eliminate previous intermittent failures across Camel tool and resource scenarios.