### PR TITLE
chore: document full-integration-test workflow usage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -105,4 +105,51 @@ To do so trigger a CI build on YOUR OWN fork using your work branch:
 gh workflow run integration-tests.yml --ref <work branch> -f version=<Wanaku version to use> -R <your github ID>/wanaku-tests
 ```
 
+## Testing From Source
+
+The `full-integration-test` workflow builds all Wanaku components from source before running the integration tests. This is useful for validating unreleased changes across repositories.
+
+Each component accepts a repository (`owner/repo`) and branch. All default to the `wanaku-ai` org on `main`.
+
+### Build all from a release branch (e.g. 0.2.x)
+
+```shell
+gh workflow run full-integration-test.yml \
+  -f wanaku_branch=0.2.x \
+  -f sdk_branch=0.2.x \
+  -f cic_branch=0.2.x \
+  -f examples_branch=0.2.x \
+  -R <your github ID>/wanaku-tests
+```
+
+### Build only wanaku from a specific branch (others use main)
+
+```shell
+gh workflow run full-integration-test.yml \
+  -f wanaku_branch=0.2.x \
+  -R <your github ID>/wanaku-tests
+```
+
+### Build from a fork
+
+```shell
+gh workflow run full-integration-test.yml \
+  -f wanaku_repo=<your github ID>/wanaku \
+  -f wanaku_branch=my-feature-branch \
+  -R <your github ID>/wanaku-tests
+```
+
+### Available inputs
+
+| Input | Default | Description |
+|-------|---------|-------------|
+| `wanaku_repo` | `wanaku-ai/wanaku` | Wanaku repository |
+| `wanaku_branch` | `main` | Wanaku branch |
+| `sdk_repo` | `wanaku-ai/wanaku-capabilities-java-sdk` | SDK repository |
+| `sdk_branch` | `main` | SDK branch |
+| `cic_repo` | `wanaku-ai/camel-integration-capability` | CIC repository |
+| `cic_branch` | `main` | CIC branch |
+| `examples_repo` | `wanaku-ai/wanaku-examples` | Examples repository |
+| `examples_branch` | `main` | Examples branch |
+
 <!-- MANUAL ADDITIONS END -->


### PR DESCRIPTION
## Summary

- Documents the `full-integration-test` workflow in CLAUDE.md with usage examples
- Covers testing from a release branch, a single component branch, and a fork
- Includes a reference table of all available workflow inputs

## Test plan

- [ ] Verify documentation renders correctly in the PR diff

## Summary by Sourcery

Document usage of the full-integration-test workflow for testing Wanaku components from source.

Documentation:
- Add CLI usage examples for running the full-integration-test workflow against release branches, specific component branches, and forks.
- Provide a reference table of all available inputs for the full-integration-test workflow in CLAUDE.md.