### PR TITLE
chore: migrate postgresql artifact for Testcontainers 2.0

### DIFF
--- a/camel-integration-capability-tests/pom.xml
+++ b/camel-integration-capability-tests/pom.xml
@@ -67,7 +67,7 @@
         <!-- Testcontainers PostgreSQL -->
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/test-common/pom.xml
+++ b/test-common/pom.xml
@@ -44,7 +44,7 @@
         <!-- PostgreSQL Testcontainer -->
         <dependency>
             <groupId>org.testcontainers</groupId>
-            <artifactId>postgresql</artifactId>
+            <artifactId>testcontainers-postgresql</artifactId>
             <scope>compile</scope>
         </dependency>
         <!-- PostgreSQL JDBC Driver (needed by PostgresServiceManager for seeding) -->

--- a/test-common/src/main/java/ai/wanaku/test/services/PostgresServiceManager.java
+++ b/test-common/src/main/java/ai/wanaku/test/services/PostgresServiceManager.java
@@ -9,7 +9,7 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.postgresql.PostgreSQLContainer;
 
 /**
  * Manages a PostgreSQL container lifecycle using Testcontainers.
@@ -24,7 +24,7 @@ public class PostgresServiceManager {
     private static final String DEFAULT_PASSWORD = "test";
     private static final String DEFAULT_DATABASE = "testdb";
 
-    private PostgreSQLContainer<?> container;
+    private PostgreSQLContainer container;
     private ManagerState state = ManagerState.STOPPED;
 
     public enum ManagerState {
@@ -45,7 +45,7 @@ public class PostgresServiceManager {
         state = ManagerState.STARTING;
         LOG.info("Starting PostgreSQL container with image {}", DEFAULT_IMAGE);
 
-        container = new PostgreSQLContainer<>(DEFAULT_IMAGE)
+        container = new PostgreSQLContainer(DEFAULT_IMAGE)
                 .withDatabaseName(DEFAULT_DATABASE)
                 .withUsername(DEFAULT_USERNAME)
                 .withPassword(DEFAULT_PASSWORD);


### PR DESCRIPTION
## Summary

- Renamed `org.testcontainers:postgresql` to `org.testcontainers:testcontainers-postgresql` in `test-common` and `camel-integration-capability-tests` POMs
- Updated import to `org.testcontainers.postgresql.PostgreSQLContainer` and removed generic type parameters (no longer generic in 2.0)

## Test plan

- [x] `mvn -DskipTests package` builds successfully
- [ ] CI integration tests pass

## Summary by Sourcery

Migrate PostgreSQL Testcontainers usage to the 2.0 artifact and API.

Enhancements:
- Update PostgreSQL container import and usage to the non-generic Testcontainers 2.0 API.

Build:
- Switch Testcontainers PostgreSQL dependency to org.testcontainers:testcontainers-postgresql in test-common and camel-integration-capability-tests modules.