### PR TITLE
feat: add REST clients for untested Router API endpoints

### DIFF
--- a/test-common/src/main/java/ai/wanaku/test/WanakuTestConstants.java
+++ b/test-common/src/main/java/ai/wanaku/test/WanakuTestConstants.java
@@ -35,7 +35,13 @@ public final class WanakuTestConstants {
     public static final String ROUTER_RESOURCES_PATH = ROUTER_API_BASE_PATH + "/resources";
     public static final String ROUTER_CAPABILITIES_PATH = ROUTER_API_BASE_PATH + "/capabilities";
     public static final String ROUTER_MANAGEMENT_DISCOVERY_PATH = ROUTER_API_BASE_PATH + "/management/discovery";
+    public static final String ROUTER_MANAGEMENT_INFO_PATH = ROUTER_API_BASE_PATH + "/management/info/version";
+    public static final String ROUTER_MANAGEMENT_STATISTICS_PATH = ROUTER_API_BASE_PATH + "/management/statistics";
     public static final String ROUTER_DATA_STORE_PATH = ROUTER_API_BASE_PATH + "/data-store";
+    public static final String ROUTER_NAMESPACES_PATH = ROUTER_API_BASE_PATH + "/namespaces";
+    public static final String ROUTER_PROMPTS_PATH = ROUTER_API_BASE_PATH + "/prompts";
+    public static final String ROUTER_FORWARDS_PATH = ROUTER_API_BASE_PATH + "/forwards";
+    public static final String ROUTER_SERVICE_CATALOG_PATH = ROUTER_API_BASE_PATH + "/service-catalog";
 
     // Port allocation
     public static final int PORT_ALLOCATION_RETRIES = 5;

--- a/test-common/src/main/java/ai/wanaku/test/base/SharedInfrastructure.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/SharedInfrastructure.java
@@ -57,6 +57,7 @@ public class SharedInfrastructure implements ExtensionContext.Store.CloseableRes
             keycloakManager.start();
         } catch (Exception e) {
             LOG.warn("Keycloak startup failed, Router will run without authentication: {}", e.getMessage());
+            keycloakManager = null;
         }
 
         if (config.getRouterJarPath() != null

--- a/test-common/src/main/java/ai/wanaku/test/client/DataStoreClient.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/DataStoreClient.java
@@ -140,8 +140,24 @@ public class DataStoreClient {
                     throw new DataStoreEntryNotFoundException("Entry '" + name + "' not found");
                 }
 
-                String encodedData = dataNode.has("data") ? dataNode.get("data").asText() : null;
+                JsonNode entryNode = dataNode;
+                if (dataNode.isArray()) {
+                    if (dataNode.isEmpty()) {
+                        throw new DataStoreEntryNotFoundException("Entry '" + name + "' not found");
+                    }
+                    entryNode = dataNode.get(0);
+                }
+
+                String encodedData = null;
+                if (entryNode.has("data")) {
+                    encodedData = entryNode.get("data").asText();
+                } else if (entryNode.has("content")) {
+                    encodedData = entryNode.get("content").asText();
+                } else if (entryNode.isTextual()) {
+                    encodedData = entryNode.asText();
+                }
                 if (encodedData == null || encodedData.isEmpty()) {
+                    LOG.warn("Entry '{}' response structure: {}", name, entryNode);
                     throw new DataStoreClientException("Entry '" + name + "' has no data");
                 }
 

--- a/test-common/src/main/java/ai/wanaku/test/client/ForwardsClient.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/ForwardsClient.java
@@ -92,10 +92,13 @@ public class ForwardsClient {
                     for (JsonNode fwd : dataNode) {
                         forwards.add(fwd);
                     }
+                } else if (dataNode.isObject()) {
+                    forwards.add(dataNode);
                 }
                 return forwards;
             } else {
-                throw new ForwardsClientException("Failed to list forwards: " + response.statusCode());
+                throw new ForwardsClientException(
+                        "Failed to list forwards: " + response.statusCode() + " - " + response.body());
             }
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) {

--- a/test-common/src/main/java/ai/wanaku/test/client/ForwardsClient.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/ForwardsClient.java
@@ -1,0 +1,213 @@
+package ai.wanaku.test.client;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ai.wanaku.test.WanakuTestConstants;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ForwardsClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ForwardsClient.class);
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final String baseUrl;
+    private final String accessToken;
+
+    public ForwardsClient(String baseUrl, String accessToken) {
+        this.baseUrl = baseUrl;
+        this.accessToken = accessToken;
+        this.httpClient =
+                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public void add(String name, String address, String namespace) {
+        LOG.debug("Adding forward: {} -> {} (namespace: {})", name, address, namespace);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("name", name);
+        body.put("address", address);
+        body.put("namespace", namespace);
+
+        try {
+            String json = objectMapper.writeValueAsString(body);
+
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_FORWARDS_PATH)
+                    .POST(HttpRequest.BodyPublishers.ofString(json))
+                    .header("Content-Type", "application/json")
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 201 || response.statusCode() == 200) {
+                LOG.debug("Forward added: {}", name);
+            } else if (response.statusCode() == 409) {
+                throw new ForwardExistsException("Forward '" + name + "' already exists");
+            } else {
+                throw new ForwardsClientException(
+                        "Failed to add forward: " + response.statusCode() + " - " + response.body());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new ForwardsClientException("Failed to add forward", e);
+        }
+    }
+
+    public List<JsonNode> list() {
+        LOG.debug("Listing forwards");
+
+        try {
+            HttpRequest request =
+                    buildRequest(WanakuTestConstants.ROUTER_FORWARDS_PATH).GET().build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            LOG.debug("List forwards response: {} - {}", response.statusCode(), response.body());
+
+            if (response.statusCode() == 200) {
+                JsonNode root = objectMapper.readTree(response.body());
+                JsonNode dataNode = root.has("data") ? root.get("data") : root;
+
+                if (dataNode == null || dataNode.isNull()) {
+                    return new ArrayList<>();
+                }
+
+                List<JsonNode> forwards = new ArrayList<>();
+                if (dataNode.isArray()) {
+                    for (JsonNode fwd : dataNode) {
+                        forwards.add(fwd);
+                    }
+                }
+                return forwards;
+            } else {
+                throw new ForwardsClientException("Failed to list forwards: " + response.statusCode());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new ForwardsClientException("Failed to list forwards", e);
+        }
+    }
+
+    public boolean remove(String name) {
+        LOG.debug("Removing forward: {}", name);
+
+        try {
+            String encodedName = URLEncoder.encode(name, StandardCharsets.UTF_8);
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_FORWARDS_PATH + "/" + encodedName)
+                    .DELETE()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            LOG.debug("Remove forward response: {} - {}", response.statusCode(), response.body());
+
+            if (response.statusCode() == 204 || response.statusCode() == 200) {
+                LOG.debug("Forward removed: {}", name);
+                return true;
+            } else if (response.statusCode() == 404) {
+                LOG.debug("Forward not found: {}", name);
+                return false;
+            } else {
+                throw new ForwardsClientException("Failed to remove forward: " + response.statusCode());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new ForwardsClientException("Failed to remove forward", e);
+        }
+    }
+
+    public void refresh(String name) {
+        LOG.debug("Refreshing forward: {}", name);
+
+        try {
+            String encodedName = URLEncoder.encode(name, StandardCharsets.UTF_8);
+            HttpRequest request = buildRequest(
+                            WanakuTestConstants.ROUTER_FORWARDS_PATH + "/" + encodedName + "/refreshes")
+                    .POST(HttpRequest.BodyPublishers.noBody())
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200 || response.statusCode() == 204) {
+                LOG.debug("Forward refreshed: {}", name);
+            } else {
+                throw new ForwardsClientException(
+                        "Failed to refresh forward '" + name + "': " + response.statusCode() + " - " + response.body());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new ForwardsClientException("Failed to refresh forward '" + name + "'", e);
+        }
+    }
+
+    public void clearAll() {
+        LOG.debug("Clearing all forwards");
+
+        List<JsonNode> forwards = list();
+        for (JsonNode fwd : forwards) {
+            String name = fwd.has("name") ? fwd.get("name").asText() : null;
+            if (name != null) {
+                try {
+                    remove(name);
+                } catch (Exception e) {
+                    LOG.warn("Failed to remove forward {}: {}", name, e.getMessage());
+                }
+            }
+        }
+        LOG.debug("Cleared {} forwards", forwards.size());
+    }
+
+    public boolean exists(String name) {
+        return list().stream()
+                .anyMatch(f -> f.has("name") && f.get("name").asText().equals(name));
+    }
+
+    private HttpRequest.Builder buildRequest(String path) {
+        HttpRequest.Builder builder =
+                HttpRequest.newBuilder().uri(URI.create(baseUrl + path)).timeout(Duration.ofSeconds(30));
+        if (accessToken != null && !accessToken.isEmpty()) {
+            builder.header("Authorization", "Bearer " + accessToken);
+        }
+        return builder;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public static class ForwardsClientException extends RuntimeException {
+        public ForwardsClientException(String message) {
+            super(message);
+        }
+
+        public ForwardsClientException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static class ForwardExistsException extends ForwardsClientException {
+        public ForwardExistsException(String message) {
+            super(message);
+        }
+    }
+}

--- a/test-common/src/main/java/ai/wanaku/test/client/ManagementClient.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/ManagementClient.java
@@ -1,0 +1,113 @@
+package ai.wanaku.test.client;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ai.wanaku.test.WanakuTestConstants;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ManagementClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ManagementClient.class);
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final String baseUrl;
+    private final String accessToken;
+
+    public ManagementClient(String baseUrl, String accessToken) {
+        this.baseUrl = baseUrl;
+        this.accessToken = accessToken;
+        this.httpClient =
+                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public JsonNode getInfo() {
+        LOG.debug("Getting router info");
+
+        try {
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_MANAGEMENT_INFO_PATH)
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            LOG.debug("Info response: {} - {}", response.statusCode(), response.body());
+
+            if (response.statusCode() == 200) {
+                JsonNode root = objectMapper.readTree(response.body());
+                return root.has("data") ? root.get("data") : root;
+            } else {
+                throw new ManagementClientException("Failed to get info: " + response.statusCode());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new ManagementClientException("Failed to get info", e);
+        }
+    }
+
+    public JsonNode getStatistics() {
+        LOG.debug("Getting router statistics");
+
+        try {
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_MANAGEMENT_STATISTICS_PATH)
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            LOG.debug("Statistics response: {} - {}", response.statusCode(), response.body());
+
+            if (response.statusCode() == 200) {
+                JsonNode root = objectMapper.readTree(response.body());
+                return root.has("data") ? root.get("data") : root;
+            } else {
+                throw new ManagementClientException("Failed to get statistics: " + response.statusCode());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new ManagementClientException("Failed to get statistics", e);
+        }
+    }
+
+    public boolean isAvailable() {
+        try {
+            getInfo();
+            return true;
+        } catch (ManagementClientException e) {
+            return false;
+        }
+    }
+
+    private HttpRequest.Builder buildRequest(String path) {
+        HttpRequest.Builder builder =
+                HttpRequest.newBuilder().uri(URI.create(baseUrl + path)).timeout(Duration.ofSeconds(30));
+        if (accessToken != null && !accessToken.isEmpty()) {
+            builder.header("Authorization", "Bearer " + accessToken);
+        }
+        return builder;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public static class ManagementClientException extends RuntimeException {
+        public ManagementClientException(String message) {
+            super(message);
+        }
+
+        public ManagementClientException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+}

--- a/test-common/src/main/java/ai/wanaku/test/client/ManagementClient.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/ManagementClient.java
@@ -44,7 +44,8 @@ public class ManagementClient {
                 JsonNode root = objectMapper.readTree(response.body());
                 return root.has("data") ? root.get("data") : root;
             } else {
-                throw new ManagementClientException("Failed to get info: " + response.statusCode());
+                throw new ManagementClientException(
+                        "Failed to get info: " + response.statusCode() + " - " + response.body());
             }
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) {
@@ -69,7 +70,8 @@ public class ManagementClient {
                 JsonNode root = objectMapper.readTree(response.body());
                 return root.has("data") ? root.get("data") : root;
             } else {
-                throw new ManagementClientException("Failed to get statistics: " + response.statusCode());
+                throw new ManagementClientException(
+                        "Failed to get statistics: " + response.statusCode() + " - " + response.body());
             }
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) {

--- a/test-common/src/main/java/ai/wanaku/test/client/NamespaceClient.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/NamespaceClient.java
@@ -101,10 +101,13 @@ public class NamespaceClient {
                     for (JsonNode ns : dataNode) {
                         namespaces.add(ns);
                     }
+                } else if (dataNode.isObject()) {
+                    namespaces.add(dataNode);
                 }
                 return namespaces;
             } else {
-                throw new NamespaceClientException("Failed to list namespaces: " + response.statusCode());
+                throw new NamespaceClientException(
+                        "Failed to list namespaces: " + response.statusCode() + " - " + response.body());
             }
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) {

--- a/test-common/src/main/java/ai/wanaku/test/client/NamespaceClient.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/NamespaceClient.java
@@ -1,0 +1,301 @@
+package ai.wanaku.test.client;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ai.wanaku.test.WanakuTestConstants;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class NamespaceClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(NamespaceClient.class);
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final String baseUrl;
+    private final String accessToken;
+
+    public NamespaceClient(String baseUrl, String accessToken) {
+        this.baseUrl = baseUrl;
+        this.accessToken = accessToken;
+        this.httpClient =
+                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    /**
+     * Creates a namespace and returns its server-generated ID.
+     */
+    public String create(String name, String path) {
+        LOG.debug("Creating namespace: {} with path: {}", name, path);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("name", name);
+        body.put("path", path);
+
+        try {
+            String json = objectMapper.writeValueAsString(body);
+
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_NAMESPACES_PATH)
+                    .POST(HttpRequest.BodyPublishers.ofString(json))
+                    .header("Content-Type", "application/json")
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 201 || response.statusCode() == 200) {
+                LOG.debug("Namespace created: {}", name);
+                JsonNode root = objectMapper.readTree(response.body());
+                JsonNode dataNode = root.has("data") ? root.get("data") : root;
+                if (dataNode != null && dataNode.has("id")) {
+                    return dataNode.get("id").asText();
+                }
+                return null;
+            } else if (response.statusCode() == 409) {
+                throw new NamespaceExistsException("Namespace '" + name + "' already exists");
+            } else {
+                throw new NamespaceClientException(
+                        "Failed to create namespace: " + response.statusCode() + " - " + response.body());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new NamespaceClientException("Failed to create namespace", e);
+        }
+    }
+
+    public List<JsonNode> list() {
+        LOG.debug("Listing namespaces");
+
+        try {
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_NAMESPACES_PATH)
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            LOG.debug("List namespaces response: {} - {}", response.statusCode(), response.body());
+
+            if (response.statusCode() == 200) {
+                JsonNode root = objectMapper.readTree(response.body());
+                JsonNode dataNode = root.has("data") ? root.get("data") : root;
+
+                if (dataNode == null || dataNode.isNull()) {
+                    return new ArrayList<>();
+                }
+
+                List<JsonNode> namespaces = new ArrayList<>();
+                if (dataNode.isArray()) {
+                    for (JsonNode ns : dataNode) {
+                        namespaces.add(ns);
+                    }
+                }
+                return namespaces;
+            } else {
+                throw new NamespaceClientException("Failed to list namespaces: " + response.statusCode());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new NamespaceClientException("Failed to list namespaces", e);
+        }
+    }
+
+    /**
+     * Shows a namespace by its server-generated ID.
+     */
+    public JsonNode show(String id) {
+        LOG.debug("Showing namespace by id: {}", id);
+
+        try {
+            String encodedId = URLEncoder.encode(id, StandardCharsets.UTF_8);
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_NAMESPACES_PATH + "/" + encodedId)
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            LOG.debug("Show namespace response: {} - {}", response.statusCode(), response.body());
+
+            if (response.statusCode() == 200) {
+                JsonNode root = objectMapper.readTree(response.body());
+                JsonNode dataNode = root.has("data") ? root.get("data") : root;
+
+                if (dataNode == null || dataNode.isNull()) {
+                    throw new NamespaceNotFoundException("Namespace with id '" + id + "' not found");
+                }
+                return dataNode;
+            } else if (response.statusCode() == 404) {
+                throw new NamespaceNotFoundException("Namespace with id '" + id + "' not found");
+            } else {
+                throw new NamespaceClientException(
+                        "Failed to show namespace: " + response.statusCode() + " - " + response.body());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new NamespaceClientException("Failed to show namespace", e);
+        }
+    }
+
+    /**
+     * Deletes a namespace by its server-generated ID.
+     */
+    public boolean delete(String id) {
+        LOG.debug("Deleting namespace by id: {}", id);
+
+        try {
+            String encodedId = URLEncoder.encode(id, StandardCharsets.UTF_8);
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_NAMESPACES_PATH + "/" + encodedId)
+                    .DELETE()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            LOG.debug("Delete namespace response: {} - {}", response.statusCode(), response.body());
+
+            if (response.statusCode() == 204 || response.statusCode() == 200) {
+                LOG.debug("Namespace deleted: {}", id);
+                return true;
+            } else if (response.statusCode() == 404) {
+                LOG.debug("Namespace not found: {}", id);
+                return false;
+            } else {
+                throw new NamespaceClientException("Failed to delete namespace: " + response.statusCode());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new NamespaceClientException("Failed to delete namespace", e);
+        }
+    }
+
+    /**
+     * Updates a namespace by its server-generated ID.
+     */
+    public void update(String id, Map<String, Object> updates) {
+        LOG.debug("Updating namespace by id: {}", id);
+
+        try {
+            String encodedId = URLEncoder.encode(id, StandardCharsets.UTF_8);
+            String json = objectMapper.writeValueAsString(updates);
+
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_NAMESPACES_PATH + "/" + encodedId)
+                    .PUT(HttpRequest.BodyPublishers.ofString(json))
+                    .header("Content-Type", "application/json")
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200 || response.statusCode() == 204) {
+                LOG.debug("Namespace updated: {}", id);
+            } else if (response.statusCode() == 404) {
+                throw new NamespaceNotFoundException("Namespace with id '" + id + "' not found");
+            } else {
+                throw new NamespaceClientException(
+                        "Failed to update namespace: " + response.statusCode() + " - " + response.body());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new NamespaceClientException("Failed to update namespace", e);
+        }
+    }
+
+    /**
+     * Cleans up stale namespaces via DELETE /namespaces/stale.
+     */
+    public void cleanupStale() {
+        LOG.debug("Cleaning up stale namespaces");
+
+        try {
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_NAMESPACES_PATH + "/stale")
+                    .DELETE()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200 || response.statusCode() == 204) {
+                LOG.debug("Stale namespaces cleaned up");
+            } else {
+                throw new NamespaceClientException(
+                        "Failed to cleanup stale namespaces: " + response.statusCode() + " - " + response.body());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new NamespaceClientException("Failed to cleanup stale namespaces", e);
+        }
+    }
+
+    /**
+     * Checks whether a namespace with the given name exists by listing all namespaces.
+     */
+    public boolean exists(String name) {
+        List<JsonNode> namespaces = list();
+        return namespaces.stream()
+                .anyMatch(ns -> ns.has("name") && name.equals(ns.get("name").asText()));
+    }
+
+    /**
+     * Finds a namespace by name and returns its server-generated ID, or null if not found.
+     */
+    public String findIdByName(String name) {
+        List<JsonNode> namespaces = list();
+        return namespaces.stream()
+                .filter(ns -> ns.has("name") && name.equals(ns.get("name").asText()))
+                .findFirst()
+                .map(ns -> ns.has("id") ? ns.get("id").asText() : null)
+                .orElse(null);
+    }
+
+    private HttpRequest.Builder buildRequest(String path) {
+        HttpRequest.Builder builder =
+                HttpRequest.newBuilder().uri(URI.create(baseUrl + path)).timeout(Duration.ofSeconds(30));
+        if (accessToken != null && !accessToken.isEmpty()) {
+            builder.header("Authorization", "Bearer " + accessToken);
+        }
+        return builder;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public static class NamespaceClientException extends RuntimeException {
+        public NamespaceClientException(String message) {
+            super(message);
+        }
+
+        public NamespaceClientException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static class NamespaceExistsException extends NamespaceClientException {
+        public NamespaceExistsException(String message) {
+            super(message);
+        }
+    }
+
+    public static class NamespaceNotFoundException extends NamespaceClientException {
+        public NamespaceNotFoundException(String message) {
+            super(message);
+        }
+    }
+}

--- a/test-common/src/main/java/ai/wanaku/test/client/PromptsClient.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/PromptsClient.java
@@ -1,0 +1,223 @@
+package ai.wanaku.test.client;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ai.wanaku.test.WanakuTestConstants;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class PromptsClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(PromptsClient.class);
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final String baseUrl;
+    private final String accessToken;
+
+    public PromptsClient(String baseUrl, String accessToken) {
+        this.baseUrl = baseUrl;
+        this.accessToken = accessToken;
+        this.httpClient =
+                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public void add(String name, String description) {
+        LOG.debug("Adding prompt: {}", name);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("name", name);
+        body.put("description", description);
+
+        try {
+            String json = objectMapper.writeValueAsString(body);
+
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_PROMPTS_PATH)
+                    .POST(HttpRequest.BodyPublishers.ofString(json))
+                    .header("Content-Type", "application/json")
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 201 || response.statusCode() == 200) {
+                LOG.debug("Prompt added: {}", name);
+            } else if (response.statusCode() == 409) {
+                throw new PromptExistsException("Prompt '" + name + "' already exists");
+            } else {
+                throw new PromptsClientException(
+                        "Failed to add prompt: " + response.statusCode() + " - " + response.body());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new PromptsClientException("Failed to add prompt", e);
+        }
+    }
+
+    public List<JsonNode> list() {
+        LOG.debug("Listing prompts");
+
+        try {
+            HttpRequest request =
+                    buildRequest(WanakuTestConstants.ROUTER_PROMPTS_PATH).GET().build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            LOG.debug("List prompts response: {} - {}", response.statusCode(), response.body());
+
+            if (response.statusCode() == 200) {
+                JsonNode root = objectMapper.readTree(response.body());
+                JsonNode dataNode = root.has("data") ? root.get("data") : root;
+
+                if (dataNode == null || dataNode.isNull()) {
+                    return new ArrayList<>();
+                }
+
+                List<JsonNode> prompts = new ArrayList<>();
+                if (dataNode.isArray()) {
+                    for (JsonNode prompt : dataNode) {
+                        prompts.add(prompt);
+                    }
+                }
+                return prompts;
+            } else {
+                throw new PromptsClientException("Failed to list prompts: " + response.statusCode());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new PromptsClientException("Failed to list prompts", e);
+        }
+    }
+
+    public boolean remove(String name) {
+        LOG.debug("Removing prompt: {}", name);
+
+        try {
+            String encodedName = URLEncoder.encode(name, StandardCharsets.UTF_8);
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_PROMPTS_PATH + "/" + encodedName)
+                    .DELETE()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            LOG.debug("Remove prompt response: {} - {}", response.statusCode(), response.body());
+
+            if (response.statusCode() == 204 || response.statusCode() == 200) {
+                LOG.debug("Prompt removed: {}", name);
+                return true;
+            } else if (response.statusCode() == 404) {
+                LOG.debug("Prompt not found: {}", name);
+                return false;
+            } else {
+                throw new PromptsClientException("Failed to remove prompt: " + response.statusCode());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new PromptsClientException("Failed to remove prompt", e);
+        }
+    }
+
+    public void edit(String name, Map<String, Object> updates) {
+        LOG.debug("Editing prompt: {}", name);
+
+        try {
+            Map<String, Object> body = new HashMap<>(updates);
+            body.put("name", name);
+            String json = objectMapper.writeValueAsString(body);
+
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_PROMPTS_PATH)
+                    .PUT(HttpRequest.BodyPublishers.ofString(json))
+                    .header("Content-Type", "application/json")
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200 || response.statusCode() == 204) {
+                LOG.debug("Prompt edited: {}", name);
+            } else if (response.statusCode() == 404) {
+                throw new PromptNotFoundException("Prompt '" + name + "' not found");
+            } else {
+                throw new PromptsClientException(
+                        "Failed to edit prompt: " + response.statusCode() + " - " + response.body());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new PromptsClientException("Failed to edit prompt", e);
+        }
+    }
+
+    public void clearAll() {
+        LOG.debug("Clearing all prompts");
+
+        List<JsonNode> prompts = list();
+        for (JsonNode prompt : prompts) {
+            String name = prompt.has("name") ? prompt.get("name").asText() : null;
+            if (name != null) {
+                try {
+                    remove(name);
+                } catch (Exception e) {
+                    LOG.warn("Failed to remove prompt {}: {}", name, e.getMessage());
+                }
+            }
+        }
+        LOG.debug("Cleared {} prompts", prompts.size());
+    }
+
+    public boolean exists(String name) {
+        return list().stream()
+                .anyMatch(p -> p.has("name") && p.get("name").asText().equals(name));
+    }
+
+    private HttpRequest.Builder buildRequest(String path) {
+        HttpRequest.Builder builder =
+                HttpRequest.newBuilder().uri(URI.create(baseUrl + path)).timeout(Duration.ofSeconds(30));
+        if (accessToken != null && !accessToken.isEmpty()) {
+            builder.header("Authorization", "Bearer " + accessToken);
+        }
+        return builder;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public static class PromptsClientException extends RuntimeException {
+        public PromptsClientException(String message) {
+            super(message);
+        }
+
+        public PromptsClientException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static class PromptExistsException extends PromptsClientException {
+        public PromptExistsException(String message) {
+            super(message);
+        }
+    }
+
+    public static class PromptNotFoundException extends PromptsClientException {
+        public PromptNotFoundException(String message) {
+            super(message);
+        }
+    }
+}

--- a/test-common/src/main/java/ai/wanaku/test/client/PromptsClient.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/PromptsClient.java
@@ -91,10 +91,13 @@ public class PromptsClient {
                     for (JsonNode prompt : dataNode) {
                         prompts.add(prompt);
                     }
+                } else if (dataNode.isObject()) {
+                    prompts.add(dataNode);
                 }
                 return prompts;
             } else {
-                throw new PromptsClientException("Failed to list prompts: " + response.statusCode());
+                throw new PromptsClientException(
+                        "Failed to list prompts: " + response.statusCode() + " - " + response.body());
             }
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) {

--- a/test-common/src/main/java/ai/wanaku/test/client/ServiceCatalogClient.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/ServiceCatalogClient.java
@@ -1,0 +1,187 @@
+package ai.wanaku.test.client;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ai.wanaku.test.WanakuTestConstants;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class ServiceCatalogClient {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ServiceCatalogClient.class);
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final String baseUrl;
+    private final String accessToken;
+
+    public ServiceCatalogClient(String baseUrl, String accessToken) {
+        this.baseUrl = baseUrl;
+        this.accessToken = accessToken;
+        this.httpClient =
+                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+        this.objectMapper = new ObjectMapper();
+    }
+
+    public void deploy(String name, String packageData) {
+        LOG.debug("Deploying service catalog: {}", name);
+
+        Map<String, Object> body = new HashMap<>();
+        body.put("name", name);
+        body.put("data", packageData);
+
+        try {
+            String json = objectMapper.writeValueAsString(body);
+
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_SERVICE_CATALOG_PATH)
+                    .POST(HttpRequest.BodyPublishers.ofString(json))
+                    .header("Content-Type", "application/json")
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 201 || response.statusCode() == 200) {
+                LOG.debug("Service catalog deployed: {}", name);
+            } else if (response.statusCode() == 409) {
+                throw new ServiceCatalogExistsException("Service catalog '" + name + "' already exists");
+            } else {
+                throw new ServiceCatalogClientException(
+                        "Failed to deploy service catalog: " + response.statusCode() + " - " + response.body());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new ServiceCatalogClientException("Failed to deploy service catalog", e);
+        }
+    }
+
+    public List<JsonNode> list() {
+        LOG.debug("Listing service catalogs");
+
+        try {
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_SERVICE_CATALOG_PATH)
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            LOG.debug("List service catalogs response: {} - {}", response.statusCode(), response.body());
+
+            if (response.statusCode() == 200) {
+                JsonNode root = objectMapper.readTree(response.body());
+                JsonNode dataNode = root.has("data") ? root.get("data") : root;
+
+                if (dataNode == null || dataNode.isNull()) {
+                    return new ArrayList<>();
+                }
+
+                List<JsonNode> catalogs = new ArrayList<>();
+                if (dataNode.isArray()) {
+                    for (JsonNode catalog : dataNode) {
+                        catalogs.add(catalog);
+                    }
+                }
+                return catalogs;
+            } else {
+                throw new ServiceCatalogClientException("Failed to list service catalogs: " + response.statusCode());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new ServiceCatalogClientException("Failed to list service catalogs", e);
+        }
+    }
+
+    public boolean remove(String name) {
+        LOG.debug("Removing service catalog: {}", name);
+
+        try {
+            String encodedName = URLEncoder.encode(name, StandardCharsets.UTF_8);
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_SERVICE_CATALOG_PATH + "/" + encodedName)
+                    .DELETE()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            LOG.debug("Remove service catalog response: {} - {}", response.statusCode(), response.body());
+
+            if (response.statusCode() == 204 || response.statusCode() == 200) {
+                LOG.debug("Service catalog removed: {}", name);
+                return true;
+            } else if (response.statusCode() == 404) {
+                LOG.debug("Service catalog not found: {}", name);
+                return false;
+            } else {
+                throw new ServiceCatalogClientException("Failed to remove service catalog: " + response.statusCode());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new ServiceCatalogClientException("Failed to remove service catalog", e);
+        }
+    }
+
+    public void clearAll() {
+        LOG.debug("Clearing all service catalogs");
+
+        List<JsonNode> catalogs = list();
+        for (JsonNode catalog : catalogs) {
+            String name = catalog.has("name") ? catalog.get("name").asText() : null;
+            if (name != null) {
+                try {
+                    remove(name);
+                } catch (Exception e) {
+                    LOG.warn("Failed to remove service catalog {}: {}", name, e.getMessage());
+                }
+            }
+        }
+        LOG.debug("Cleared {} service catalogs", catalogs.size());
+    }
+
+    public boolean exists(String name) {
+        return list().stream()
+                .anyMatch(c -> c.has("name") && c.get("name").asText().equals(name));
+    }
+
+    private HttpRequest.Builder buildRequest(String path) {
+        HttpRequest.Builder builder =
+                HttpRequest.newBuilder().uri(URI.create(baseUrl + path)).timeout(Duration.ofSeconds(30));
+        if (accessToken != null && !accessToken.isEmpty()) {
+            builder.header("Authorization", "Bearer " + accessToken);
+        }
+        return builder;
+    }
+
+    public String getBaseUrl() {
+        return baseUrl;
+    }
+
+    public static class ServiceCatalogClientException extends RuntimeException {
+        public ServiceCatalogClientException(String message) {
+            super(message);
+        }
+
+        public ServiceCatalogClientException(String message, Throwable cause) {
+            super(message, cause);
+        }
+    }
+
+    public static class ServiceCatalogExistsException extends ServiceCatalogClientException {
+        public ServiceCatalogExistsException(String message) {
+            super(message);
+        }
+    }
+}

--- a/test-common/src/main/java/ai/wanaku/test/client/ServiceCatalogClient.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/ServiceCatalogClient.java
@@ -92,10 +92,13 @@ public class ServiceCatalogClient {
                     for (JsonNode catalog : dataNode) {
                         catalogs.add(catalog);
                     }
+                } else if (dataNode.isObject()) {
+                    catalogs.add(dataNode);
                 }
                 return catalogs;
             } else {
-                throw new ServiceCatalogClientException("Failed to list service catalogs: " + response.statusCode());
+                throw new ServiceCatalogClientException(
+                        "Failed to list service catalogs: " + response.statusCode() + " - " + response.body());
             }
         } catch (IOException | InterruptedException e) {
             if (e instanceof InterruptedException) {


### PR DESCRIPTION
## Summary

Add five new test infrastructure clients to `test-common` covering Router features with zero integration test coverage. This is the foundation for new test modules in follow-up PRs.

**New clients:**
- `ForwardsClient` — CRUD for `/api/v1/forwards` (MCP-to-MCP bridge, namespace-aware)
- `NamespaceClient` — CRUD for `/api/v1/namespaces` (ID-based show/delete/update)
- `PromptsClient` — CRUD for `/api/v1/prompts` (add, list, remove, edit)
- `ManagementClient` — `/api/v1/management/info/version` and `/statistics`
- `ServiceCatalogClient` — CRUD for `/api/v1/service-catalog`

**Updates to existing code:**
- `WanakuTestConstants` — new API path constants
- `DataStoreClient` — handle array responses from `?name=` queries
- `SharedInfrastructure` — null keycloakManager on realm creation failure

**Review feedback addressed:**
- All `list()` methods handle single-object `data` responses (not just arrays)
- All error exceptions include response body for better diagnostics
- Base class extraction declined — follows existing standalone client pattern

## Test plan
- [x] `mvn -DskipTests compile` passes
- [x] All existing tests continue passing (verified on CI)