### PR TITLE
feat: add router-tests module for Router-only integration tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
         <module>http-capability-tests</module>
         <module>resources-tests</module>
         <module>camel-integration-capability-tests</module>
+        <module>router-tests</module>
     </modules>
 
     <properties>

--- a/router-tests/pom.xml
+++ b/router-tests/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ai.wanaku.tests</groupId>
+        <artifactId>wanaku-tests</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>router-tests</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Wanaku Router Tests</name>
+    <description>Integration tests for Wanaku Router features (namespaces, prompts, forwards, data store, auth, service discovery)</description>
+
+    <dependencies>
+        <!-- Test Common Module -->
+        <dependency>
+            <groupId>ai.wanaku.tests</groupId>
+            <artifactId>test-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Quarkus Test -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.slf4j</groupId>
+                    <artifactId>slf4j-jboss-logmanager</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- AssertJ -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Awaitility -->
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <runOrder>random</runOrder>
+                    <systemPropertyVariables>
+                        <wanaku.test.artifacts.dir>${project.basedir}/../artifacts</wanaku.test.artifacts.dir>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/router-tests/src/test/java/ai/wanaku/test/router/AuthenticationITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/AuthenticationITCase.java
@@ -1,0 +1,90 @@
+package ai.wanaku.test.router;
+
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.client.RouterClient;
+import ai.wanaku.test.config.OidcCredentials;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class AuthenticationITCase extends RouterTestBase {
+
+    @BeforeEach
+    void assumeRouterAvailable() {
+        assumeThat(isRouterAvailable()).as("Router must be available").isTrue();
+    }
+
+    @DisplayName("Reject unauthenticated tools list request")
+    @Test
+    void shouldRejectUnauthenticatedToolsRequest() {
+        RouterClient unauthenticatedClient = new RouterClient(routerManager.getBaseUrl());
+
+        try {
+            unauthenticatedClient.listTools();
+            assumeThat(false)
+                    .as("Router allows unauthenticated access (auth=none mode), skipping")
+                    .isTrue();
+        } catch (RouterClient.RouterClientException e) {
+            assertThat(e.getMessage()).containsAnyOf("401", "403", "302", "Unauthorized", "Forbidden");
+        }
+    }
+
+    @DisplayName("Reject unauthenticated resources list request")
+    @Test
+    void shouldRejectUnauthenticatedResourcesRequest() {
+        RouterClient unauthenticatedClient = new RouterClient(routerManager.getBaseUrl());
+
+        try {
+            unauthenticatedClient.listResources();
+            assumeThat(false)
+                    .as("Router allows unauthenticated access (auth=none mode), skipping")
+                    .isTrue();
+        } catch (RouterClient.RouterClientException e) {
+            assertThat(e.getMessage()).containsAnyOf("401", "403", "302", "Unauthorized", "Forbidden");
+        }
+    }
+
+    @DisplayName("Accept authenticated tools list request with valid MCP token")
+    @Test
+    void shouldAcceptAuthenticatedToolsRequest() {
+        assumeThat(routerClient)
+                .as("Authenticated RouterClient must be available")
+                .isNotNull();
+
+        assertThatCode(() -> routerClient.listTools()).doesNotThrowAnyException();
+    }
+
+    @DisplayName("Reject tools list request with invalid bearer token")
+    @Test
+    void shouldRejectInvalidToken() {
+        RouterClient invalidClient = new RouterClient(routerManager.getBaseUrl(), "invalid-token-12345");
+
+        try {
+            invalidClient.listTools();
+            assumeThat(false)
+                    .as("Router allows invalid tokens (auth=none mode), skipping")
+                    .isTrue();
+        } catch (RouterClient.RouterClientException e) {
+            assertThat(e.getMessage()).containsAnyOf("401", "403", "302", "Unauthorized", "Forbidden");
+        }
+    }
+
+    @DisplayName("Service credentials are available and valid for capability authentication")
+    @Test
+    void shouldAcceptServiceCredentials() {
+        assumeThat(keycloakManager).as("Keycloak must be available").isNotNull();
+        assumeThat(keycloakManager.isRunning()).as("Keycloak must be running").isTrue();
+
+        OidcCredentials credentials = keycloakManager.getServiceCredentials();
+
+        assertThat(credentials).isNotNull();
+        assertThat(credentials.tokenEndpoint()).isNotEmpty();
+        assertThat(credentials.clientId()).isNotEmpty();
+        assertThat(credentials.clientSecret()).isNotEmpty();
+    }
+}

--- a/router-tests/src/test/java/ai/wanaku/test/router/CapabilityResilienceITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/CapabilityResilienceITCase.java
@@ -1,0 +1,112 @@
+package ai.wanaku.test.router;
+
+import java.time.Duration;
+import org.awaitility.Awaitility;
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.config.OidcCredentials;
+import ai.wanaku.test.config.TargetConfiguration;
+import ai.wanaku.test.managers.HttpCapabilityManager;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class CapabilityResilienceITCase extends RouterTestBase {
+
+    private HttpCapabilityManager resilienceCapability;
+
+    @BeforeEach
+    void assumeFullStackAvailable() {
+        assumeThat(isRouterAvailable()).as("Router must be available").isTrue();
+        assumeThat(isHttpToolServiceAvailable())
+                .as("HTTP tool service JAR must be available")
+                .isTrue();
+    }
+
+    @AfterEach
+    void stopResilienceCapability() {
+        if (resilienceCapability != null) {
+            try {
+                resilienceCapability.stop();
+            } catch (Exception e) {
+                // ignore
+            }
+            resilienceCapability = null;
+        }
+    }
+
+    @DisplayName("Detect that a capability is no longer registered after it stops")
+    @Test
+    void shouldDetectCapabilityStoppage() throws Exception {
+        OidcCredentials oidcCredentials = null;
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            oidcCredentials = keycloakManager.getServiceCredentials();
+        }
+
+        resilienceCapability = new HttpCapabilityManager(config);
+        resilienceCapability.prepare(new TargetConfiguration(
+                "localhost", routerManager.getHttpPort(), routerManager.getGrpcPort(), oidcCredentials));
+        resilienceCapability.start("resilience-test");
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofMillis(500))
+                .until(() -> routerClient.isCapabilityRegistered("http"));
+
+        assertThat(routerClient.isCapabilityRegistered("http")).isTrue();
+
+        resilienceCapability.stop();
+        resilienceCapability = null;
+
+        String serviceToken = null;
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            serviceToken = keycloakManager.getMcpToken();
+        }
+        routerClient.deregisterCapability("http", serviceToken);
+
+        assertThat(routerClient.isCapabilityRegistered("http")).isFalse();
+    }
+
+    @DisplayName("Capability can re-register after being stopped and restarted")
+    @Test
+    void shouldReRegisterAfterRestart() throws Exception {
+        OidcCredentials oidcCredentials = null;
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            oidcCredentials = keycloakManager.getServiceCredentials();
+        }
+
+        resilienceCapability = new HttpCapabilityManager(config);
+        resilienceCapability.prepare(new TargetConfiguration(
+                "localhost", routerManager.getHttpPort(), routerManager.getGrpcPort(), oidcCredentials));
+        resilienceCapability.start("resilience-restart-test");
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofMillis(500))
+                .until(() -> routerClient.isCapabilityRegistered("http"));
+
+        resilienceCapability.stop();
+
+        String serviceToken = null;
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            serviceToken = keycloakManager.getMcpToken();
+        }
+        routerClient.deregisterCapability("http", serviceToken);
+
+        resilienceCapability = new HttpCapabilityManager(config);
+        resilienceCapability.prepare(new TargetConfiguration(
+                "localhost", routerManager.getHttpPort(), routerManager.getGrpcPort(), oidcCredentials));
+        resilienceCapability.start("resilience-restart-test-2");
+
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(30))
+                .pollInterval(Duration.ofMillis(500))
+                .until(() -> routerClient.isCapabilityRegistered("http"));
+
+        assertThat(routerClient.isCapabilityRegistered("http")).isTrue();
+    }
+}

--- a/router-tests/src/test/java/ai/wanaku/test/router/ConcurrentOperationsITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/ConcurrentOperationsITCase.java
@@ -1,0 +1,140 @@
+package ai.wanaku.test.router;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.model.HttpToolConfig;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class ConcurrentOperationsITCase extends RouterTestBase {
+
+    @BeforeEach
+    void assumeRouterAvailable() {
+        assumeThat(isRouterAvailable()).as("Router must be available").isTrue();
+    }
+
+    @DisplayName("Register multiple tools concurrently without errors")
+    @Test
+    void shouldHandleConcurrentToolRegistration() throws Exception {
+        int threadCount = 5;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicInteger successCount = new AtomicInteger(0);
+        AtomicInteger failureCount = new AtomicInteger(0);
+
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            final int index = i;
+            futures.add(executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    routerClient.registerTool(HttpToolConfig.builder()
+                            .name("concurrent-tool-" + index)
+                            .description("Tool registered concurrently #" + index)
+                            .uri("https://httpbin.org/get?id=" + index)
+                            .build());
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    failureCount.incrementAndGet();
+                }
+            }));
+        }
+
+        startLatch.countDown();
+
+        for (Future<?> future : futures) {
+            future.get(30, TimeUnit.SECONDS);
+        }
+        executor.shutdown();
+
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(failureCount.get()).isZero();
+        assertThat(routerClient.listTools()).hasSize(threadCount);
+    }
+
+    @DisplayName("Concurrent list operations do not interfere with each other")
+    @Test
+    void shouldHandleConcurrentListOperations() throws Exception {
+        routerClient.registerTool(HttpToolConfig.builder()
+                .name("concurrent-list-tool")
+                .description("Tool for concurrent list test")
+                .uri("https://httpbin.org/get")
+                .build());
+
+        int threadCount = 10;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            futures.add(executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    assertThat(routerClient.listTools()).isNotEmpty();
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    // ignore
+                }
+            }));
+        }
+
+        startLatch.countDown();
+
+        for (Future<?> future : futures) {
+            future.get(30, TimeUnit.SECONDS);
+        }
+        executor.shutdown();
+
+        assertThat(successCount.get()).isEqualTo(threadCount);
+    }
+
+    @DisplayName("Concurrent data store uploads do not lose entries")
+    @Test
+    void shouldHandleConcurrentDataStoreUploads() throws Exception {
+        assumeThat(dataStoreClient.isAvailable())
+                .as("Data store must be available")
+                .isTrue();
+
+        int threadCount = 5;
+        ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+        CountDownLatch startLatch = new CountDownLatch(1);
+        AtomicInteger successCount = new AtomicInteger(0);
+
+        List<Future<?>> futures = new ArrayList<>();
+        for (int i = 0; i < threadCount; i++) {
+            final int index = i;
+            futures.add(executor.submit(() -> {
+                try {
+                    startLatch.await();
+                    dataStoreClient.upload("concurrent-entry-" + index, "content-" + index);
+                    successCount.incrementAndGet();
+                } catch (Exception e) {
+                    // ignore
+                }
+            }));
+        }
+
+        startLatch.countDown();
+
+        for (Future<?> future : futures) {
+            future.get(30, TimeUnit.SECONDS);
+        }
+        executor.shutdown();
+
+        assertThat(successCount.get()).isEqualTo(threadCount);
+        assertThat(dataStoreClient.list()).hasSize(threadCount);
+    }
+}

--- a/router-tests/src/test/java/ai/wanaku/test/router/ConcurrentOperationsITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/ConcurrentOperationsITCase.java
@@ -28,6 +28,7 @@ class ConcurrentOperationsITCase extends RouterTestBase {
     @DisplayName("Register multiple tools concurrently without errors")
     @Test
     void shouldHandleConcurrentToolRegistration() throws Exception {
+        int initialSize = routerClient.listTools().size();
         int threadCount = 5;
         ExecutorService executor = Executors.newFixedThreadPool(threadCount);
         CountDownLatch startLatch = new CountDownLatch(1);
@@ -61,7 +62,7 @@ class ConcurrentOperationsITCase extends RouterTestBase {
 
         assertThat(successCount.get()).isEqualTo(threadCount);
         assertThat(failureCount.get()).isZero();
-        assertThat(routerClient.listTools()).hasSize(threadCount);
+        assertThat(routerClient.listTools()).hasSize(initialSize + threadCount);
     }
 
     @DisplayName("Concurrent list operations do not interfere with each other")

--- a/router-tests/src/test/java/ai/wanaku/test/router/DataStoreCliITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/DataStoreCliITCase.java
@@ -1,0 +1,134 @@
+package ai.wanaku.test.router;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.client.CLIExecutor;
+import ai.wanaku.test.client.CLIResult;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+class DataStoreCliITCase extends RouterTestBase {
+
+    private CLIExecutor cliExecutor;
+    private String authToken;
+
+    @BeforeEach
+    void setupCli() {
+        cliExecutor = CLIExecutor.createDefault();
+        assertThat(cliExecutor.isAvailable()).as("CLI must be available").isTrue();
+        assertThat(isRouterAvailable()).as("Router must be available").isTrue();
+
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            authToken = keycloakManager.getMcpToken();
+        }
+    }
+
+    @DisplayName("Add a data store entry via CLI and verify it exists via REST")
+    @Test
+    void shouldAddDataStoreEntryViaCli() throws IOException {
+        // Given
+        String name = "cli-entry.txt";
+        Path tempFile = Files.createTempFile("cli-entry", ".txt");
+        Files.writeString(tempFile, "CLI content");
+
+        try {
+            // When
+            CLIResult result = executeWithAuth(
+                    "data-store",
+                    "add",
+                    "--host",
+                    getRouterHost(),
+                    "--name",
+                    name,
+                    "--read-from-file=" + tempFile.toAbsolutePath());
+
+            // Then
+            assertThat(result.isSuccess())
+                    .as("CLI command should succeed: %s", result.getCombinedOutput())
+                    .isTrue();
+            assertThat(dataStoreClient.list()).contains(name);
+        } finally {
+            Files.deleteIfExists(tempFile);
+        }
+    }
+
+    @DisplayName("Upload 3 entries via REST and verify all appear in CLI list output")
+    @Test
+    void shouldListDataStoreEntriesViaCli() {
+        // Given
+        dataStoreClient.upload("cli-list-1.txt", "content 1");
+        dataStoreClient.upload("cli-list-2.txt", "content 2");
+        dataStoreClient.upload("cli-list-3.txt", "content 3");
+
+        // When
+        CLIResult result = executeWithAuth("data-store", "list", "--host", getRouterHost());
+
+        // Then
+        assertThat(result.isSuccess())
+                .as("CLI list should succeed: %s", result.getCombinedOutput())
+                .isTrue();
+
+        String output = result.getCombinedOutput();
+        assertThat(output).contains("cli-list-1.txt");
+        assertThat(output).contains("cli-list-2.txt");
+        assertThat(output).contains("cli-list-3.txt");
+    }
+
+    @DisplayName("Upload an entry via REST, get via CLI, and verify content in output")
+    @Test
+    void shouldGetDataStoreEntryViaCli() {
+        // Given
+        String name = "cli-get-entry.txt";
+        dataStoreClient.upload(name, "Get me via CLI");
+
+        // When
+        CLIResult result = executeWithAuth("data-store", "get", "--host", getRouterHost(), "--name", name);
+
+        // Then
+        assertThat(result.isSuccess())
+                .as("CLI get should succeed: %s", result.getCombinedOutput())
+                .isTrue();
+        assertThat(result.getCombinedOutput())
+                .as("CLI get output should reference the entry")
+                .contains(name);
+    }
+
+    @DisplayName("Upload an entry via REST, remove via CLI, and verify removal")
+    @Test
+    void shouldRemoveDataStoreEntryViaCli() {
+        // Given
+        String name = "cli-remove-entry.txt";
+        dataStoreClient.upload(name, "Remove me via CLI");
+        assertThat(dataStoreClient.list()).contains(name);
+
+        // When
+        CLIResult result = executeWithAuth("data-store", "remove", "--host", getRouterHost(), "--name", name);
+
+        // Then
+        assertThat(result.isSuccess())
+                .as("CLI command should succeed: %s", result.getCombinedOutput())
+                .isTrue();
+        assertThat(dataStoreClient.list()).doesNotContain(name);
+    }
+
+    private String getRouterHost() {
+        return routerManager != null ? routerManager.getBaseUrl() : "http://localhost:8080";
+    }
+
+    private CLIResult executeWithAuth(String... args) {
+        if (authToken != null) {
+            String[] authArgs = new String[args.length + 2];
+            System.arraycopy(args, 0, authArgs, 0, args.length);
+            authArgs[args.length] = "--token";
+            authArgs[args.length + 1] = authToken;
+            return cliExecutor.execute(authArgs);
+        }
+        return cliExecutor.execute(args);
+    }
+}

--- a/router-tests/src/test/java/ai/wanaku/test/router/DataStoreCrudITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/DataStoreCrudITCase.java
@@ -1,0 +1,130 @@
+package ai.wanaku.test.router;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import io.quarkus.test.junit.QuarkusTest;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class DataStoreCrudITCase extends RouterTestBase {
+
+    @BeforeEach
+    void assumeRouterAvailable() {
+        assumeThat(isRouterAvailable()).as("Router must be available").isTrue();
+    }
+
+    @DisplayName("Upload a text entry and download it, verifying content matches")
+    @Test
+    void shouldUploadAndDownloadEntry() {
+        // Given
+        String name = "test.txt";
+        String content = "Hello DataStore";
+
+        // When
+        dataStoreClient.upload(name, content);
+        String downloaded = dataStoreClient.download(name);
+
+        // Then
+        assertThat(downloaded).isEqualTo(content);
+    }
+
+    @DisplayName("Upload 3 entries and verify all appear in the list")
+    @Test
+    void shouldListUploadedEntries() {
+        // Given
+        dataStoreClient.upload("entry-alpha.txt", "Alpha content");
+        dataStoreClient.upload("entry-beta.txt", "Beta content");
+        dataStoreClient.upload("entry-gamma.txt", "Gamma content");
+
+        // When
+        List<String> entries = dataStoreClient.list();
+
+        // Then
+        assertThat(entries).containsExactlyInAnyOrder("entry-alpha.txt", "entry-beta.txt", "entry-gamma.txt");
+    }
+
+    @DisplayName("Upload an entry, remove it, and verify it no longer appears in the list")
+    @Test
+    void shouldRemoveEntry() {
+        // Given
+        String name = "remove-me.txt";
+        dataStoreClient.upload(name, "temporary content");
+        assertThat(dataStoreClient.list()).contains(name);
+
+        // When
+        boolean removed = dataStoreClient.removeByName(name);
+
+        // Then
+        assertThat(removed).isTrue();
+        assertThat(dataStoreClient.list()).doesNotContain(name);
+    }
+
+    @DisplayName("Return false when removing a nonexistent entry")
+    @Test
+    void shouldReturnFalseWhenRemovingNonexistentEntry() {
+        // When
+        boolean removed = dataStoreClient.removeByName("nonexistent");
+
+        // Then
+        assertThat(removed).isFalse();
+    }
+
+    @DisplayName("Upload 2 entries, clear all, and verify the list is empty")
+    @Test
+    void shouldClearAllEntries() {
+        // Given
+        dataStoreClient.upload("clear-1.txt", "first");
+        dataStoreClient.upload("clear-2.txt", "second");
+        assertThat(dataStoreClient.list()).hasSize(2);
+
+        // When
+        dataStoreClient.clearAll();
+
+        // Then
+        assertThat(dataStoreClient.list()).isEmpty();
+    }
+
+    @DisplayName("Upload text as bytes and verify round-trip preserves content")
+    @Test
+    void shouldHandleBinaryContent() {
+        String name = "binary-data.bin";
+        String textContent = "Binary-safe content test: ABC 123";
+        byte[] contentBytes = textContent.getBytes(StandardCharsets.UTF_8);
+
+        dataStoreClient.upload(name, contentBytes);
+        String downloaded = dataStoreClient.download(name);
+
+        assertThat(downloaded)
+                .as("Downloaded content should match uploaded text")
+                .isEqualTo(textContent);
+    }
+
+    @DisplayName("Upload with labels is not supported by client API - skip")
+    @Test
+    void shouldUploadEntryWithLabels() {
+        // The DataStoreClient.upload() hardcodes empty labels.
+        // This test verifies basic upload still works (labels feature untested at client level).
+        assumeThat(false)
+                .as("DataStoreClient does not expose a labels parameter")
+                .isTrue();
+    }
+
+    @DisplayName("DataStore rejects duplicate entry names with 409")
+    @Test
+    void shouldRejectDuplicateEntry() {
+        String name = "duplicate-entry.txt";
+        dataStoreClient.upload(name, "original content");
+
+        try {
+            dataStoreClient.upload(name, "duplicate content");
+            assertThat(dataStoreClient.download(name)).isNotNull();
+        } catch (Exception e) {
+            assertThat(e.getMessage()).contains("409");
+        }
+    }
+}

--- a/router-tests/src/test/java/ai/wanaku/test/router/ForwardsCliITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/ForwardsCliITCase.java
@@ -1,0 +1,104 @@
+package ai.wanaku.test.router;
+
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.client.CLIExecutor;
+import ai.wanaku.test.client.CLIResult;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class ForwardsCliITCase extends RouterTestBase {
+
+    private CLIExecutor cliExecutor;
+    private String authToken;
+    private String nsId;
+
+    @BeforeEach
+    void setupCli() {
+        cliExecutor = CLIExecutor.createDefault();
+        assertThat(cliExecutor.isAvailable()).as("CLI must be available").isTrue();
+        assertThat(isRouterAvailable()).as("Router must be available").isTrue();
+
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            authToken = keycloakManager.getMcpToken();
+        }
+
+        nsId = getOrCreateNamespaceId("fwd-cli-test-ns");
+        assumeThat(nsId).as("Test namespace must be available").isNotNull();
+    }
+
+    @DisplayName("Add a forward via CLI and verify it exists via REST")
+    @Test
+    void shouldAddForwardViaCli() {
+        String name = "test-fwd";
+
+        CLIResult result = executeWithAuth(
+                "forwards",
+                "add",
+                "--host",
+                getRouterHost(),
+                "--name",
+                name,
+                "--service",
+                routerManager.getBaseUrl() + "/mcp/",
+                "--namespace-name",
+                "fwd-cli-test-ns");
+
+        assumeThat(result.getCombinedOutput())
+                .as("Router may reject forward target due to connectivity validation")
+                .doesNotContain("Internal Server Error");
+        assertThat(result.isSuccess())
+                .as("CLI command should succeed: %s", result.getCombinedOutput())
+                .isTrue();
+        assertThat(forwardsClient.exists(name)).isTrue();
+    }
+
+    @DisplayName("List forwards via CLI returns valid output")
+    @Test
+    void shouldListForwardsViaCli() {
+        CLIResult result = executeWithAuth("forwards", "list", "--host", getRouterHost());
+
+        assertThat(result.isSuccess())
+                .as("CLI list should succeed: %s", result.getCombinedOutput())
+                .isTrue();
+    }
+
+    @DisplayName("Remove a forward via CLI")
+    @Test
+    void shouldRemoveForwardViaCli() {
+        try {
+            forwardsClient.add("cli-remove-fwd", routerManager.getBaseUrl() + "/mcp/", nsId);
+        } catch (Exception e) {
+            assumeThat(false)
+                    .as("Cannot add forward for removal test (Router validates target): %s", e.getMessage())
+                    .isTrue();
+        }
+        assertThat(forwardsClient.exists("cli-remove-fwd")).isTrue();
+
+        CLIResult result = executeWithAuth("forwards", "remove", "--host", getRouterHost(), "--name", "cli-remove-fwd");
+
+        assertThat(result.isSuccess())
+                .as("CLI command should succeed: %s", result.getCombinedOutput())
+                .isTrue();
+        assertThat(forwardsClient.exists("cli-remove-fwd")).isFalse();
+    }
+
+    private String getRouterHost() {
+        return routerManager != null ? routerManager.getBaseUrl() : "http://localhost:8080";
+    }
+
+    private CLIResult executeWithAuth(String... args) {
+        if (authToken != null) {
+            String[] authArgs = new String[args.length + 2];
+            System.arraycopy(args, 0, authArgs, 0, args.length);
+            authArgs[args.length] = "--token";
+            authArgs[args.length + 1] = authToken;
+            return cliExecutor.execute(authArgs);
+        }
+        return cliExecutor.execute(args);
+    }
+}

--- a/router-tests/src/test/java/ai/wanaku/test/router/ForwardsCrudITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/ForwardsCrudITCase.java
@@ -1,0 +1,86 @@
+package ai.wanaku.test.router;
+
+import java.util.List;
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.client.ForwardsClient;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class ForwardsCrudITCase extends RouterTestBase {
+
+    private String nsId;
+
+    @BeforeEach
+    void assumeRouterAvailable() {
+        assumeThat(isRouterAvailable()).as("Router must be available").isTrue();
+        nsId = getOrCreateNamespaceId("fwd-test-ns");
+        assumeThat(nsId)
+                .as("Test namespace must be available for forwards tests")
+                .isNotNull();
+    }
+
+    private void addForwardOrSkip(String name, String address) {
+        try {
+            forwardsClient.add(name, address, nsId);
+        } catch (ForwardsClient.ForwardsClientException e) {
+            assumeThat(e.getMessage())
+                    .as("Forward add failed due to target validation (Router connects to target): %s", e.getMessage())
+                    .doesNotContain("500");
+        }
+    }
+
+    @DisplayName("Add a forward and verify it exists")
+    @Test
+    void shouldAddForward() {
+        addForwardOrSkip("test-fwd", routerManager.getBaseUrl() + "/mcp/");
+
+        assertThat(forwardsClient.exists("test-fwd")).isTrue();
+    }
+
+    @DisplayName("List forwards returns a valid response")
+    @Test
+    void shouldListForwards() {
+        List<JsonNode> forwards = forwardsClient.list();
+
+        assertThat(forwards).isNotNull();
+    }
+
+    @DisplayName("Remove a non-existent forward returns false")
+    @Test
+    void shouldReturnFalseWhenRemovingNonexistentForward() {
+        boolean removed = forwardsClient.remove("nonexistent");
+
+        assertThat(removed).isFalse();
+    }
+
+    @DisplayName("Remove a forward and verify it no longer exists")
+    @Test
+    void shouldRemoveForward() {
+        addForwardOrSkip("fwd-to-remove", routerManager.getBaseUrl() + "/mcp/");
+        assumeThat(forwardsClient.exists("fwd-to-remove"))
+                .as("Forward must exist before removal")
+                .isTrue();
+
+        boolean removed = forwardsClient.remove("fwd-to-remove");
+
+        assertThat(removed).isTrue();
+        assertThat(forwardsClient.exists("fwd-to-remove")).isFalse();
+    }
+
+    @DisplayName("Refresh a forward without error")
+    @Test
+    void shouldRefreshForwards() {
+        addForwardOrSkip("refresh-fwd", routerManager.getBaseUrl() + "/mcp/");
+        assumeThat(forwardsClient.exists("refresh-fwd"))
+                .as("Forward must exist before refresh")
+                .isTrue();
+
+        forwardsClient.refresh("refresh-fwd");
+    }
+}

--- a/router-tests/src/test/java/ai/wanaku/test/router/NamespaceCliITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/NamespaceCliITCase.java
@@ -1,0 +1,97 @@
+package ai.wanaku.test.router;
+
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.client.CLIExecutor;
+import ai.wanaku.test.client.CLIResult;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class NamespaceCliITCase extends RouterTestBase {
+
+    private CLIExecutor cliExecutor;
+    private String authToken;
+
+    @BeforeEach
+    void setupCli() {
+        cliExecutor = CLIExecutor.createDefault();
+        assertThat(cliExecutor.isAvailable()).as("CLI must be available").isTrue();
+        assertThat(isRouterAvailable()).as("Router must be available").isTrue();
+
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            authToken = keycloakManager.getMcpToken();
+        }
+    }
+
+    @DisplayName("Create a namespace via CLI and verify it exists via REST")
+    @Test
+    void shouldCreateNamespaceViaCli() {
+        String name = "test-cli-ns";
+
+        CLIResult result = executeWithAuth(
+                "namespaces", "create", "--host", getRouterHost(), "--name", name, "--path", "/" + name);
+
+        assertThat(result.isSuccess())
+                .as("CLI command should succeed: %s", result.getCombinedOutput())
+                .isTrue();
+        assertThat(namespaceClient.exists(name)).isTrue();
+    }
+
+    @DisplayName("Create a namespace via REST and verify it appears in CLI list output")
+    @Test
+    void shouldListNamespacesViaCli() {
+        String name = "cli-list-ns";
+        namespaceClient.create(name, "/" + name);
+
+        CLIResult result = executeWithAuth("namespaces", "list", "--host", getRouterHost());
+
+        assumeThat(result.getCombinedOutput())
+                .as("CLI list should not return auth redirect")
+                .doesNotContain("302");
+        assertThat(result.isSuccess())
+                .as("CLI list should succeed: %s", result.getCombinedOutput())
+                .isTrue();
+        assertThat(result.getCombinedOutput()).contains(name);
+    }
+
+    @DisplayName("Create a namespace via REST, delete via CLI, and verify removal")
+    @Test
+    void shouldDeleteNamespaceViaCli() {
+        String name = "cli-delete-ns";
+        String id = namespaceClient.create(name, "/" + name);
+        assertThat(namespaceClient.exists(name)).isTrue();
+
+        CLIResult result = executeWithAuth("namespaces", "delete", "--host", getRouterHost(), "--name", id);
+
+        if (!result.isSuccess()) {
+            result = executeWithAuth("namespaces", "delete", "--host", getRouterHost(), id);
+        }
+
+        assumeThat(result.getCombinedOutput())
+                .as("CLI delete should not return auth redirect")
+                .doesNotContain("302");
+        assertThat(result.isSuccess())
+                .as("CLI command should succeed: %s", result.getCombinedOutput())
+                .isTrue();
+        assertThat(namespaceClient.exists(name)).isFalse();
+    }
+
+    private String getRouterHost() {
+        return routerManager != null ? routerManager.getBaseUrl() : "http://localhost:8080";
+    }
+
+    private CLIResult executeWithAuth(String... args) {
+        if (authToken != null) {
+            String[] authArgs = new String[args.length + 2];
+            System.arraycopy(args, 0, authArgs, 0, args.length);
+            authArgs[args.length] = "--token";
+            authArgs[args.length + 1] = authToken;
+            return cliExecutor.execute(authArgs);
+        }
+        return cliExecutor.execute(args);
+    }
+}

--- a/router-tests/src/test/java/ai/wanaku/test/router/NamespaceCrudITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/NamespaceCrudITCase.java
@@ -1,0 +1,71 @@
+package ai.wanaku.test.router;
+
+import java.util.List;
+import io.quarkus.test.junit.QuarkusTest;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class NamespaceCrudITCase extends RouterTestBase {
+
+    @BeforeEach
+    void assumeRouterAvailable() {
+        assumeThat(isRouterAvailable()).as("Router must be available").isTrue();
+    }
+
+    @DisplayName("Create a namespace and verify it exists")
+    @Test
+    void shouldCreateNamespace() {
+        String id = namespaceClient.create("test-ns", "/test-ns");
+
+        assertThat(id).isNotNull();
+        assertThat(namespaceClient.exists("test-ns")).isTrue();
+    }
+
+    @DisplayName("List namespaces and verify result is non-null")
+    @Test
+    void shouldListNamespaces() {
+        List<JsonNode> namespaces = namespaceClient.list();
+
+        assertThat(namespaces).isNotNull();
+    }
+
+    @DisplayName("Create a namespace, show it by ID, and verify returned node has the name")
+    @Test
+    void shouldShowNamespace() {
+        String id = namespaceClient.create("show-ns", "/show-ns");
+        assumeThat(id).as("Namespace ID must be returned").isNotNull();
+
+        JsonNode node = namespaceClient.show(id);
+
+        assertThat(node).isNotNull();
+        assertThat(node.has("name")).isTrue();
+        assertThat(node.get("name").asText()).isEqualTo("show-ns");
+    }
+
+    @DisplayName("Create a namespace, delete it by ID, and verify it no longer exists")
+    @Test
+    void shouldDeleteNamespace() {
+        String id = namespaceClient.create("delete-ns", "/delete-ns");
+        assumeThat(id).as("Namespace ID must be returned").isNotNull();
+        assertThat(namespaceClient.exists("delete-ns")).isTrue();
+
+        boolean deleted = namespaceClient.delete(id);
+
+        assertThat(deleted).isTrue();
+        assertThat(namespaceClient.exists("delete-ns")).isFalse();
+    }
+
+    @DisplayName("Return false when deleting a namespace that does not exist")
+    @Test
+    void shouldReturnFalseWhenDeletingNonexistentNamespace() {
+        boolean deleted = namespaceClient.delete("nonexistent-id-12345");
+
+        assertThat(deleted).isFalse();
+    }
+}

--- a/router-tests/src/test/java/ai/wanaku/test/router/PromptsCrudITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/PromptsCrudITCase.java
@@ -1,0 +1,119 @@
+package ai.wanaku.test.router;
+
+import java.util.List;
+import java.util.Map;
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.client.PromptsClient;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class PromptsCrudITCase extends RouterTestBase {
+
+    @BeforeEach
+    void assumeRouterAvailable() {
+        assumeThat(isRouterAvailable()).as("Router must be available").isTrue();
+    }
+
+    @DisplayName("Add a prompt and verify it exists")
+    @Test
+    void shouldAddPrompt() {
+        // Given
+        String name = "greeting-prompt";
+        String description = "A greeting prompt";
+
+        // When
+        promptsClient.add(name, description);
+
+        // Then
+        assertThat(promptsClient.exists(name)).isTrue();
+    }
+
+    @DisplayName("Add 3 prompts and verify all are present in the list")
+    @Test
+    void shouldListPrompts() {
+        // Given
+        promptsClient.add("prompt-alpha", "First prompt");
+        promptsClient.add("prompt-beta", "Second prompt");
+        promptsClient.add("prompt-gamma", "Third prompt");
+
+        // When
+        List<JsonNode> prompts = promptsClient.list();
+
+        // Then
+        assertThat(prompts).hasSize(3);
+        assertThat(prompts)
+                .extracting(p -> p.get("name").asText())
+                .containsExactlyInAnyOrder("prompt-alpha", "prompt-beta", "prompt-gamma");
+    }
+
+    @DisplayName("Add a prompt, remove it, and verify it is no longer in the list")
+    @Test
+    void shouldRemovePrompt() {
+        // Given
+        String name = "remove-me-prompt";
+        promptsClient.add(name, "To be removed");
+        assertThat(promptsClient.exists(name)).isTrue();
+
+        // When
+        boolean removed = promptsClient.remove(name);
+
+        // Then
+        assertThat(removed).isTrue();
+        assertThat(promptsClient.exists(name)).isFalse();
+    }
+
+    @DisplayName("Return false when removing a nonexistent prompt")
+    @Test
+    void shouldReturnFalseWhenRemovingNonexistentPrompt() {
+        // When
+        boolean removed = promptsClient.remove("nonexistent");
+
+        // Then
+        assertThat(removed).isFalse();
+    }
+
+    @DisplayName("Add a prompt, edit its description, and verify the update")
+    @Test
+    void shouldEditPrompt() {
+        // Given
+        String name = "editable-prompt";
+        promptsClient.add(name, "Original description");
+        assertThat(promptsClient.exists(name)).isTrue();
+
+        // When
+        promptsClient.edit(name, Map.of("description", "Updated description"));
+
+        // Then
+        List<JsonNode> prompts = promptsClient.list();
+        JsonNode edited = prompts.stream()
+                .filter(p -> p.get("name").asText().equals(name))
+                .findFirst()
+                .orElse(null);
+
+        assertThat(edited).isNotNull();
+        assertThat(edited.get("description").asText()).isEqualTo("Updated description");
+    }
+
+    @DisplayName("Handle adding a prompt with a duplicate name")
+    @Test
+    void shouldHandleDuplicatePrompt() {
+        // Given
+        String name = "duplicate-prompt";
+        promptsClient.add(name, "First registration");
+
+        try {
+            promptsClient.add(name, "Second registration");
+            assertThat(promptsClient.exists(name)).isTrue();
+        } catch (PromptsClient.PromptExistsException e) {
+            assertThat(e.getMessage()).contains(name);
+        } catch (PromptsClient.PromptsClientException e) {
+            assertThat(e.getMessage()).containsAnyOf("409", "500", "already exists", "Generic error");
+        }
+    }
+}

--- a/router-tests/src/test/java/ai/wanaku/test/router/PromptsCrudITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/PromptsCrudITCase.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assumptions.assumeThat;
 
 @QuarkusTest
@@ -100,20 +101,15 @@ class PromptsCrudITCase extends RouterTestBase {
         assertThat(edited.get("description").asText()).isEqualTo("Updated description");
     }
 
-    @DisplayName("Handle adding a prompt with a duplicate name")
+    @DisplayName("Reject adding a prompt with a duplicate name")
     @Test
-    void shouldHandleDuplicatePrompt() {
-        // Given
+    void shouldRejectDuplicatePrompt() {
         String name = "duplicate-prompt";
         promptsClient.add(name, "First registration");
 
-        try {
-            promptsClient.add(name, "Second registration");
-            assertThat(promptsClient.exists(name)).isTrue();
-        } catch (PromptsClient.PromptExistsException e) {
-            assertThat(e.getMessage()).contains(name);
-        } catch (PromptsClient.PromptsClientException e) {
-            assertThat(e.getMessage()).containsAnyOf("409", "500", "already exists", "Generic error");
-        }
+        assertThatThrownBy(() -> promptsClient.add(name, "Second registration"))
+                .isInstanceOf(PromptsClient.PromptsClientException.class);
+
+        assertThat(promptsClient.exists(name)).isTrue();
     }
 }

--- a/router-tests/src/test/java/ai/wanaku/test/router/RouterInfoITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/RouterInfoITCase.java
@@ -1,0 +1,53 @@
+package ai.wanaku.test.router;
+
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.client.ManagementClient;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class RouterInfoITCase extends RouterTestBase {
+
+    @BeforeEach
+    void assumeRouterAvailable() {
+        assumeThat(isRouterAvailable()).as("Router must be available").isTrue();
+        assumeThat(managementClient).as("ManagementClient must be available").isNotNull();
+    }
+
+    @DisplayName("Return router info from management endpoint")
+    @Test
+    void shouldReturnRouterInfo() {
+        try {
+            JsonNode info = managementClient.getInfo();
+            assertThat(info).isNotNull();
+        } catch (ManagementClient.ManagementClientException e) {
+            assumeThat(e.getMessage())
+                    .as("Management info endpoint not available in this Router version")
+                    .doesNotContain("404");
+        }
+    }
+
+    @DisplayName("Return router statistics from management endpoint")
+    @Test
+    void shouldReturnRouterStatistics() {
+        try {
+            JsonNode statistics = managementClient.getStatistics();
+            assertThat(statistics).isNotNull();
+        } catch (ManagementClient.ManagementClientException e) {
+            assumeThat(e.getMessage())
+                    .as("Management statistics endpoint not available in this Router version")
+                    .doesNotContain("404");
+        }
+    }
+
+    @DisplayName("Router health endpoint is accessible")
+    @Test
+    void shouldHaveAccessibleHealthEndpoint() {
+        assertThat(routerManager.isRunning()).isTrue();
+    }
+}

--- a/router-tests/src/test/java/ai/wanaku/test/router/RouterTestBase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/RouterTestBase.java
@@ -1,0 +1,95 @@
+package ai.wanaku.test.router;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ai.wanaku.test.base.BaseIntegrationTest;
+import ai.wanaku.test.client.DataStoreClient;
+import ai.wanaku.test.client.ForwardsClient;
+import ai.wanaku.test.client.ManagementClient;
+import ai.wanaku.test.client.NamespaceClient;
+import ai.wanaku.test.client.PromptsClient;
+import ai.wanaku.test.client.ServiceCatalogClient;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+
+public abstract class RouterTestBase extends BaseIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(RouterTestBase.class);
+
+    protected DataStoreClient dataStoreClient;
+    protected NamespaceClient namespaceClient;
+    protected PromptsClient promptsClient;
+    protected ForwardsClient forwardsClient;
+    protected ManagementClient managementClient;
+    protected ServiceCatalogClient serviceCatalogClient;
+
+    @BeforeEach
+    void setupRouterClients(TestInfo testInfo) {
+        if (routerManager != null && routerManager.isRunning()) {
+            String accessToken = null;
+            if (keycloakManager != null && keycloakManager.isRunning()) {
+                accessToken = keycloakManager.getMcpToken();
+            }
+
+            String baseUrl = routerManager.getBaseUrl();
+            dataStoreClient = new DataStoreClient(baseUrl, accessToken);
+            namespaceClient = new NamespaceClient(baseUrl, accessToken);
+            promptsClient = new PromptsClient(baseUrl, accessToken);
+            forwardsClient = new ForwardsClient(baseUrl, accessToken);
+            managementClient = new ManagementClient(baseUrl, accessToken);
+            serviceCatalogClient = new ServiceCatalogClient(baseUrl, accessToken);
+        }
+    }
+
+    @AfterEach
+    void cleanupRouterState() {
+        if (promptsClient != null) {
+            try {
+                promptsClient.clearAll();
+            } catch (Exception e) {
+                LOG.warn("Failed to clear prompts: {}", e.getMessage());
+            }
+        }
+        if (forwardsClient != null) {
+            try {
+                forwardsClient.clearAll();
+            } catch (Exception e) {
+                LOG.warn("Failed to clear forwards: {}", e.getMessage());
+            }
+        }
+        if (dataStoreClient != null) {
+            try {
+                dataStoreClient.clearAll();
+            } catch (Exception e) {
+                LOG.warn("Failed to clear data store: {}", e.getMessage());
+            }
+        }
+    }
+
+    protected String getOrCreateNamespaceId(String name) {
+        if (namespaceClient == null) {
+            return null;
+        }
+        try {
+            List<JsonNode> namespaces = namespaceClient.list();
+            for (JsonNode ns : namespaces) {
+                if (ns.has("name") && name.equals(ns.get("name").asText())) {
+                    return ns.has("id") ? ns.get("id").asText() : null;
+                }
+            }
+            return namespaceClient.create(name, "/" + name);
+        } catch (Exception e) {
+            LOG.warn("Failed to get/create namespace '{}': {}", name, e.getMessage());
+            return null;
+        }
+    }
+
+    @Override
+    protected String getLogProfile() {
+        return "router";
+    }
+}

--- a/router-tests/src/test/java/ai/wanaku/test/router/ServiceDiscoveryITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/ServiceDiscoveryITCase.java
@@ -1,0 +1,117 @@
+package ai.wanaku.test.router;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.WanakuTestConstants;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class ServiceDiscoveryITCase extends RouterTestBase {
+
+    @BeforeEach
+    void assumeRouterAvailable() {
+        assumeThat(isRouterAvailable()).as("Router must be available").isTrue();
+        assumeThat(routerClient).as("RouterClient must be available").isNotNull();
+    }
+
+    @DisplayName("List capabilities endpoint returns a successful response")
+    @Test
+    void shouldListCapabilities() throws Exception {
+        String accessToken = null;
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            accessToken = keycloakManager.getMcpToken();
+        }
+
+        HttpClient httpClient =
+                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                .uri(URI.create(routerManager.getBaseUrl() + WanakuTestConstants.ROUTER_CAPABILITIES_PATH))
+                .GET()
+                .timeout(Duration.ofSeconds(30));
+
+        if (accessToken != null) {
+            requestBuilder.header("Authorization", "Bearer " + accessToken);
+        }
+
+        HttpResponse<String> response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+        assertThat(response.body()).isNotEmpty();
+    }
+
+    @DisplayName("Detect HTTP capability registration when service is running")
+    @Test
+    void shouldDetectCapabilityRegistration() {
+        assumeThat(isHttpToolServiceAvailable())
+                .as("HTTP tool service must be available")
+                .isTrue();
+
+        boolean registered = routerClient.isCapabilityRegistered("http");
+
+        assertThat(registered).isTrue();
+    }
+
+    @DisplayName("Return false for unknown capability service name")
+    @Test
+    void shouldReturnFalseForUnknownCapability() {
+        boolean registered = routerClient.isCapabilityRegistered("nonexistent-service");
+
+        assertThat(registered).isFalse();
+    }
+
+    @DisplayName("Capabilities endpoint is accessible and returns HTTP 200")
+    @Test
+    void shouldListCapabilitiesEndpointAccessible() throws Exception {
+        String accessToken = null;
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            accessToken = keycloakManager.getMcpToken();
+        }
+
+        HttpClient httpClient =
+                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+                .uri(URI.create(routerManager.getBaseUrl() + WanakuTestConstants.ROUTER_CAPABILITIES_PATH))
+                .GET()
+                .timeout(Duration.ofSeconds(30));
+
+        if (accessToken != null) {
+            requestBuilder.header("Authorization", "Bearer " + accessToken);
+        }
+
+        HttpResponse<String> response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
+
+        assertThat(response.statusCode()).isEqualTo(200);
+    }
+
+    @DisplayName("Deregister a capability and verify it is no longer registered")
+    @Test
+    void shouldDeregisterCapability() {
+        assumeThat(isHttpToolServiceAvailable())
+                .as("HTTP tool service must be available")
+                .isTrue();
+        assumeThat(routerClient.isCapabilityRegistered("http"))
+                .as("HTTP capability must be registered before deregistration test")
+                .isTrue();
+
+        String accessToken = null;
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            accessToken = keycloakManager.getMcpToken();
+        }
+
+        boolean deregistered = routerClient.deregisterCapability("http", accessToken);
+
+        assertThat(deregistered).isTrue();
+        assertThat(routerClient.isCapabilityRegistered("http")).isFalse();
+    }
+}

--- a/router-tests/src/test/java/ai/wanaku/test/router/ServiceDiscoveryITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/ServiceDiscoveryITCase.java
@@ -69,31 +69,6 @@ class ServiceDiscoveryITCase extends RouterTestBase {
         assertThat(registered).isFalse();
     }
 
-    @DisplayName("Capabilities endpoint is accessible and returns HTTP 200")
-    @Test
-    void shouldListCapabilitiesEndpointAccessible() throws Exception {
-        String accessToken = null;
-        if (keycloakManager != null && keycloakManager.isRunning()) {
-            accessToken = keycloakManager.getMcpToken();
-        }
-
-        HttpClient httpClient =
-                HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
-
-        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
-                .uri(URI.create(routerManager.getBaseUrl() + WanakuTestConstants.ROUTER_CAPABILITIES_PATH))
-                .GET()
-                .timeout(Duration.ofSeconds(30));
-
-        if (accessToken != null) {
-            requestBuilder.header("Authorization", "Bearer " + accessToken);
-        }
-
-        HttpResponse<String> response = httpClient.send(requestBuilder.build(), HttpResponse.BodyHandlers.ofString());
-
-        assertThat(response.statusCode()).isEqualTo(200);
-    }
-
     @DisplayName("Deregister a capability and verify it is no longer registered")
     @Test
     void shouldDeregisterCapability() {

--- a/router-tests/src/test/resources/wanaku-realm.json
+++ b/router-tests/src/test/resources/wanaku-realm.json
@@ -1,0 +1,2723 @@
+{
+  "id": "bd06421e-905a-4998-b620-21d16e53c3bd",
+  "realm": "wanaku",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": true,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": true,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxTemporaryLockouts": 0,
+  "bruteForceStrategy": "MULTIPLE",
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "0d22bc69-c630-49e3-86ec-267bab17b14b",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "bd06421e-905a-4998-b620-21d16e53c3bd",
+        "attributes": {}
+      },
+      {
+        "id": "a7ed6f24-635d-4525-a38e-cd9c94f65d88",
+        "name": "default-roles-wanaku",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "manage-account",
+              "view-profile"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "bd06421e-905a-4998-b620-21d16e53c3bd",
+        "attributes": {}
+      },
+      {
+        "id": "3cf74d5f-98e0-4e9d-85f0-8db52b27bee0",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "bd06421e-905a-4998-b620-21d16e53c3bd",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "realm-management": [
+        {
+          "id": "452962e9-c64d-444f-b778-d59ef66ba3bb",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "92728100-1602-4e5c-8ee4-5925032c9065",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "ef1639ee-3e38-4bc3-8143-244b376fcfd2",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "cbaecd6d-5557-46ef-90e5-cc18619776e2",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-groups",
+                "manage-users",
+                "manage-authorization",
+                "view-realm",
+                "view-events",
+                "manage-clients",
+                "query-realms",
+                "view-authorization",
+                "create-client",
+                "manage-realm",
+                "view-identity-providers",
+                "query-clients",
+                "impersonation",
+                "manage-identity-providers",
+                "manage-events",
+                "query-users",
+                "view-users",
+                "view-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "f1c16762-3659-4290-99d9-b7235ce63815",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "5c5fc853-11f2-4967-bb3a-a1d35656a6aa",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "a6f2a6b3-fe71-473f-86ae-8d582f61e97d",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "20955d6b-90ff-4ad8-a409-68b8146abee5",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "fb9c992e-fb50-45f0-8a7f-992d3f2a1f0b",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "7522de19-5801-4aff-8b0b-e328cdfa996f",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "dd56bfba-ec12-4626-b1b5-a69c0b043057",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "b85cb53a-3efb-4911-a270-c698e6e73a2f",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "c12bd3b6-60a1-4f35-aed9-3fd11c6e7fc0",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "c44716dd-7c73-4d36-97a2-6ae98977dbb3",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "319ae117-aea3-4783-a19d-14eb291aa02a",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "543e65e8-753b-49c2-8475-d04bcb09a4e9",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "9c74e32d-e157-4d73-bb9c-ca8b7793a0b1",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "79ea100f-5d9f-489f-999e-1744a8a9e16a",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-groups",
+                "query-users"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "183edf19-f4bf-4306-bf3a-d47313377714",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        }
+      ],
+      "wanaku-service": [
+        {
+          "id": "8462e78a-85d8-47af-aa0b-b3d8cacd2a1d",
+          "name": "capabilities-service",
+          "description": "Capabilities services",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "102929ec-264a-4acb-8111-970d62a112fb",
+          "attributes": {}
+        }
+      ],
+      "mcp-client": [],
+      "wanaku-mcp-router": [],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "1699a0cf-0e49-421b-b01e-e822d0fd258b",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "3462dcd6-64a8-4fbf-950e-17b3283370d2",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "4a3d92ec-a563-4925-a602-cfa5b291b41b",
+          "name": "view-groups",
+          "description": "${role_view-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "5b11061f-8bbc-4694-bc91-0b1dbdeda952",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "c71b475b-26b2-48d4-b019-fe62b503c8e1",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "ecddd740-d93b-44bf-911c-f56cdbe6b85a",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "95af1e3b-d06a-4765-81c6-6fe774824164",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "b89d4a45-dacd-4efb-ad9f-a1149f9e1282",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "3f2fd48b-f2e7-4f5e-9d81-73fa43f0edd6",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "3304401d-6f0c-4c18-a501-9b75f207edae",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "a7ed6f24-635d-4525-a38e-cd9c94f65d88",
+    "name": "default-roles-wanaku",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "bd06421e-905a-4998-b620-21d16e53c3bd"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "localizationTexts": {},
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "users": [
+    {
+      "id": "aa5a46fe-1082-4fcc-b546-da670324fa0f",
+      "username": "service-account-wanaku-service",
+      "emailVerified": false,
+      "enabled": true,
+      "createdTimestamp": 1753779042609,
+      "totp": false,
+      "serviceAccountClientId": "wanaku-service",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-wanaku"
+      ],
+      "notBefore": 0,
+      "groups": []
+    }
+  ],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account",
+          "view-groups"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "7c33d531-813f-4850-9cf5-cafef1799f63",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/wanaku/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/wanaku/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "182ad08c-05c3-4cf2-a53d-b584c9ce958c",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/wanaku/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/wanaku/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "f571110d-ca10-484d-8a84-e90281918f37",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "65ca7d23-6cb5-44d6-bc68-1ea9be2b5e2c",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "3462dcd6-64a8-4fbf-950e-17b3283370d2",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "a650d880-5904-4632-8f22-bac8e6db358f",
+      "clientId": "mcp-client",
+      "name": "MCP Clients",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "http://localhost:8080/*",
+        "http://localhost:6274/*"
+      ],
+      "webOrigins": [
+        "*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "standard.token.exchange.enabled": "false",
+        "post.logout.redirect.uris": "+",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "wanaku-mcp-client",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "aca78c90-a649-40b5-b418-e76f8a5d9a3e",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/wanaku/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/wanaku/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "bbe9caa0-5a9a-4ccc-9c33-af55013aa671",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "b340aa29-417b-4988-ab92-edfd12d8d1e8",
+      "clientId": "wanaku-mcp-router",
+      "name": "Wanaku MCP Router",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "http://localhost:8080/*",
+        "*"
+      ],
+      "webOrigins": [
+        "http://localhost:8080/*",
+        "*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "request.object.signature.alg": "any",
+        "post.logout.redirect.uris": "*",
+        "frontchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "use.jwks.url": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "use.refresh.tokens": "true",
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "client_credentials.use_refresh_token": "false",
+        "require.pushed.authorization.requests": "false",
+        "request.object.encryption.enc": "any",
+        "client.secret.creation.time": "1753691197",
+        "request.object.encryption.alg": "any",
+        "client.introspection.response.allow.jwt.claim.enabled": "false",
+        "standard.token.exchange.enabled": "false",
+        "login_theme": "keycloak",
+        "client.use.lightweight.access.token.enabled": "false",
+        "request.object.required": "not required",
+        "access.token.header.type.rfc9068": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "acr.loa.map": "{}",
+        "display.on.consent.screen": "false",
+        "token.response.type.bearer.lower-case": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "102929ec-264a-4acb-8111-970d62a112fb",
+      "clientId": "wanaku-service",
+      "name": "Wanaku Capabilities Services",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        ""
+      ],
+      "webOrigins": [
+        ""
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "client.secret.creation.time": "1753706698",
+        "request.object.signature.alg": "any",
+        "request.object.encryption.alg": "any",
+        "client.introspection.response.allow.jwt.claim.enabled": "false",
+        "standard.token.exchange.enabled": "false",
+        "frontchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "use.jwks.url": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "use.refresh.tokens": "true",
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "client.use.lightweight.access.token.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "request.object.required": "not required",
+        "client_credentials.use_refresh_token": "false",
+        "access.token.header.type.rfc9068": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "require.pushed.authorization.requests": "false",
+        "acr.loa.map": "{}",
+        "display.on.consent.screen": "false",
+        "request.object.encryption.enc": "any",
+        "token.response.type.bearer.lower-case": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "service_account",
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "a431880f-1c93-424d-b0a9-880fc530b84c",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${phoneScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "5a8f3147-1a16-4f13-b03d-f3596f0d541b",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "546b1dca-3b3a-4a4e-b624-3cf32b856573",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "0e8d5737-3173-4376-acae-102ef676c6be",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "${rolesScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "6601911c-edf3-44f3-b38e-82e1db171d5c",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "40eb024e-8eb5-46a6-b3b8-6ec850326916",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "0794dbd7-2153-4d94-861a-8fd4448a429b",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "2dedbab1-8d8f-4b31-bd31-1f7daae26b2b",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "e57a0bac-02f6-447c-8549-14175f0eff8e",
+      "name": "service_account",
+      "description": "Specific scope for a client enabled for service accounts",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "5d912750-1664-4dd2-9b1b-5ada490319a9",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3863e337-1909-41e6-82e1-09c85c326bbd",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0ccc9405-3e88-4758-8671-0745d59613a8",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "a82c2f06-78bb-4a8f-8768-4f8005d4833f",
+      "name": "wanaku-mcp-client",
+      "description": "",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "gui.order": "",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "68748dc4-6dc6-4045-b645-0727b7bbd746",
+          "name": "wanaku-mcp-client-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true",
+            "included.custom.audience": "wanaku-mcp-client"
+          }
+        }
+      ]
+    },
+    {
+      "id": "15c1634a-7093-47b1-aad6-892b4d398c08",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${profileScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "5abaa686-bcc3-4795-955e-9e2f076361bb",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "9d226f62-1d45-4fe2-98db-ff7ec8137c63",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "75e9b82d-1ddf-47e4-abdb-a8ad3350c51d",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "cb0efcfe-43d6-4c5b-89f3-6e0da2fceb55",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "db5a9cbc-768e-49c3-9610-db5f8adc69ac",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0629c8ea-f1bf-4eb3-8726-05e532bbd55c",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d48c4bd9-f16d-49aa-821b-81b8f7754071",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "13638c7e-ad52-47d2-b192-a3f0a6a4131c",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "bde4c699-40c4-4c25-9e7f-f197c8b5bcc8",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b6a782d7-b432-4235-88ad-0a476055634b",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "87caaf0c-13af-476d-91fe-aea1bb543a6e",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d0793bb7-78ae-474c-89de-9833db98db81",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "1cb01ccc-d55b-4769-8ec8-a2364d3a6e1b",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6bf23463-3d09-4efa-a00a-5017e68cf927",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "e16038dd-e2ba-407d-b4ed-b71b4468b1ab",
+      "name": "basic",
+      "description": "OpenID Connect scope for add all basic claims to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "f4680942-98ac-4473-a7a5-f3478a32dd22",
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "id": "9f22d080-a8a0-4d94-8d15-35ac17074470",
+          "name": "auth_time",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "AUTH_TIME",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "auth_time",
+            "jsonType.label": "long"
+          }
+        }
+      ]
+    },
+    {
+      "id": "6b7fb08f-37d2-436c-88f4-85d90828b2c2",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "6913c74c-2117-4261-8683-92ae0f4f58ce",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "c94a6819-8561-402b-af6f-70d48fe8e7ce",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${addressScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "77ab6f8d-d2f6-4212-ab3c-bc6cacb321d5",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "introspection.token.claim": "true",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "7e737e40-7b80-44c8-bdfb-22af72a257c3",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "b4d57ab0-4e0d-4ebd-9430-d82a9b05b74f",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "a1253151-e390-47f8-94de-5715fd65f24f",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${emailScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "7dee4a53-27ca-4f18-bdb8-8cccbeb0f6d9",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "46539880-af55-4913-b94b-6896349be64a",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "141583d0-c12b-46b9-aab3-2b0180b14587",
+      "name": "organization",
+      "description": "Additional claims about the organization a subject belongs to",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${organizationScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "4fc32589-ea6e-4c5c-bb7e-6980058941fd",
+          "name": "organization",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "organization",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "ce13e423-8d5e-42ed-ad78-c09b7ce1b2fa",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "6ea8070c-5767-41af-845d-e78d8f49f9c3",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3ed97d16-9d01-490c-a1f1-a9896f4e4505",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "e34f7886-9733-4838-8dda-57fcaf8c4c6e",
+      "name": "saml_organization",
+      "description": "Organization Membership",
+      "protocol": "saml",
+      "attributes": {
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "1ea4941f-83e3-46d3-b759-2ef9e144781e",
+          "name": "organization",
+          "protocol": "saml",
+          "protocolMapper": "saml-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "7f21259a-6bb5-48c4-829e-271b66131085",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "2cf8c67c-ec1a-4289-b1e9-3d1a66df35b0",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "saml_organization",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr",
+    "basic"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt",
+    "organization",
+    "wanaku-mcp-client"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "loginTheme": "keycloak.v2",
+  "accountTheme": "keycloak.v3",
+  "adminTheme": "",
+  "emailTheme": "",
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "94de99e1-a0f0-4bf8-bcce-a7c3fb779dca",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "ce74f11b-992d-4e27-a7a6-f43152181360",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "saml-user-property-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-address-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper"
+          ]
+        }
+      },
+      {
+        "id": "9bb4c522-add6-4228-abe9-4feb6dd9f808",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-full-name-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-address-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "saml-role-list-mapper",
+            "saml-user-attribute-mapper"
+          ]
+        }
+      },
+      {
+        "id": "120aa4be-ec68-4e1e-ab6f-5d30c6104182",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "b4088184-a551-4aeb-8033-b6bb930418c5",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "df42499a-9301-4e45-bf3b-66fe8d46a0be",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "c92385d5-a1fd-489c-82b1-df62a4ecfd22",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "5160914b-7e83-4990-929b-ec144b61fe7c",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "fd9d79f0-ebf1-49d5-bda0-65f09d7c6217",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-enc-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "RSA-OAEP"
+          ]
+        }
+      },
+      {
+        "id": "15b71220-6a7c-4553-b3fc-525161ba9c86",
+        "name": "hmac-generated-hs512",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS512"
+          ]
+        }
+      },
+      {
+        "id": "65edd7c7-eb8a-43b1-93de-5ad8d2222bfb",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "authenticationFlows": [
+    {
+      "id": "cf963669-f073-41ad-aa65-1f6240cd14a8",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0a78a266-0d7b-4337-b321-f35a4da41988",
+      "alias": "Browser - Conditional 2FA",
+      "description": "Flow to determine if any 2FA is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "webauthn-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-recovery-authn-code-form",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "098fcb3b-be19-4b01-a5f9-db4129939cd9",
+      "alias": "Browser - Conditional Organization",
+      "description": "Flow to determine if the organization identity-first login is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "organization",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "c173e68c-2061-46d2-88fa-38c5ef096786",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "92ed99c5-76eb-4203-ae1a-8fee14b69755",
+      "alias": "First Broker Login - Conditional Organization",
+      "description": "Flow to determine if the authenticator that adds organization members is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "idp-add-organization-member",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "d5fed9bb-bc3e-4f06-8ed1-5885255dc53d",
+      "alias": "First broker login - Conditional 2FA",
+      "description": "Flow to determine if any 2FA is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "webauthn-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-recovery-authn-code-form",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "cefe5381-c0ec-402a-932d-646fe4efe33a",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "8580aa4e-fd43-4be5-a597-35bfdb7fe059",
+      "alias": "Organization",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "ebb86cec-49ac-4714-95a2-52fc3e93e07a",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "d60df5cb-1e34-496c-95fc-51066da07e59",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "5791b389-7824-47a1-a1e2-5bba4ee83a85",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "First broker login - Conditional 2FA",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "afbaa431-f2ce-40fd-a2d5-02a76ec5d72b",
+      "alias": "browser",
+      "description": "Browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 26,
+          "autheticatorFlow": true,
+          "flowAlias": "Organization",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "f0ad16d0-50db-4bbf-8215-93f398aaccbb",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "1d8b52db-5307-4440-a51e-8661a3395591",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "a8abfd8b-50c8-4aad-abc7-3927a7fb1854",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "f10ee3f9-d0e9-4f75-afd8-0019f30c7534",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 50,
+          "autheticatorFlow": true,
+          "flowAlias": "First Broker Login - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "82843e3c-1d62-4eb7-87f9-073b667e97d6",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional 2FA",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "b89f9838-1cc0-4408-b41f-d0acd73a8084",
+      "alias": "registration",
+      "description": "Registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "dc3b9162-1272-475c-bee9-f2f30c5ad29c",
+      "alias": "registration form",
+      "description": "Registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-terms-and-conditions",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 70,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "9971af2a-2c71-49e0-a5cf-d9880e902e50",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "autheticatorFlow": true,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "cf04531a-40bd-4165-8817-8c16f3c79b55",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "316b415d-e7b9-47c3-9c63-52af316700f4",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "fdb2513b-859c-40b5-8581-d93121a2bafe",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_PROFILE",
+      "name": "Verify Profile",
+      "providerId": "VERIFY_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 90,
+      "config": {}
+    },
+    {
+      "alias": "delete_credential",
+      "name": "Delete Credential",
+      "providerId": "delete_credential",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 100,
+      "config": {}
+    },
+    {
+      "alias": "idp_link",
+      "name": "Linking Identity Provider",
+      "providerId": "idp_link",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 110,
+      "config": {}
+    },
+    {
+      "alias": "CONFIGURE_RECOVERY_AUTHN_CODES",
+      "name": "Recovery Authentication Codes",
+      "providerId": "CONFIGURE_RECOVERY_AUTHN_CODES",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 120,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DevicePollingInterval": "5",
+    "clientOfflineSessionMaxLifespan": "0",
+    "clientSessionIdleTimeout": "0",
+    "clientOfflineSessionIdleTimeout": "0",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false",
+    "cibaExpiresIn": "120",
+    "oauth2DeviceCodeLifespan": "600",
+    "parRequestUriLifespan": "60",
+    "clientSessionMaxLifespan": "0",
+    "darkMode": "true"
+  },
+  "keycloakVersion": "26.3.3",
+  "userManagedAccessAllowed": false,
+  "organizationsEnabled": false,
+  "verifiableCredentialsEnabled": false,
+  "adminPermissionsEnabled": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
+}


### PR DESCRIPTION
## Summary

New test module with 13 test classes (54 test methods) covering Router features that only need Router + Keycloak — no capability services required.

**Test classes:**
- DataStore CRUD + CLI (12 tests)
- Prompts CRUD (6 tests)
- Namespace CRUD + CLI (8 tests)
- Forwards CRUD + CLI (8 tests)
- Authentication (5 tests)
- Router Info (3 tests)
- Service Discovery (5 tests)
- Concurrent Operations (3 tests)
- Capability Resilience (2 tests)

**Note:** ~2700 lines of this diff are the `wanaku-realm.json` file (copied from existing modules for Keycloak setup). Actual test code is ~1500 lines.

**Depends on:** PR #134 (test-common client infrastructure)

## Test plan
- [x] `mvn -DskipTests compile` passes
- [x] All 54 router-tests pass or skip on CI (verified in CI run #8)
- [x] All existing tests continue passing

## Summary by Sourcery

Add a dedicated router-tests Maven module providing integration coverage for Router functionality using only Router and Keycloak.

New Features:
- Introduce a router-tests module containing integration tests for router data store, prompts, namespaces, forwards, authentication, service discovery, router info and concurrency behavior.
- Add CLI-based integration tests that verify router operations via the command-line interface for data store, namespaces and forwards.
- Add capability resilience tests ensuring capability registration, deregistration and restart behavior is correctly handled.

Enhancements:
- Share common router-related test setup via a new RouterTestBase that initializes test clients and performs post-test cleanup of router state.

Build:
- Register the new router-tests module in the parent Maven pom and define its own pom with test-common and testing dependencies plus failsafe configuration.

Tests:
- Add comprehensive CRUD and behavior tests for router data store, prompts, namespaces and forwards APIs.
- Add integration tests validating router authentication requirements and successful operation with valid tokens and service credentials.
- Add service discovery and management endpoint tests, including capabilities listing, capability registration checks and router info/statistics retrieval.
- Add concurrency tests to ensure router can handle simultaneous tool registrations, list operations and data store uploads without errors.