### PR TITLE
feat: add mcp-forwarding-tests and extend existing test modules

### DIFF
--- a/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolCliExtendedITCase.java
+++ b/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolCliExtendedITCase.java
@@ -1,0 +1,79 @@
+package ai.wanaku.test.http;
+
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.client.CLIExecutor;
+import ai.wanaku.test.client.CLIResult;
+import ai.wanaku.test.model.HttpToolConfig;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+class HttpToolCliExtendedITCase extends HttpCapabilityTestBase {
+
+    private CLIExecutor cliExecutor;
+    private String authToken;
+
+    @BeforeEach
+    void setupCli() {
+        cliExecutor = CLIExecutor.createDefault();
+        assertThat(cliExecutor.isAvailable()).as("CLI must be available").isTrue();
+        assertThat(isRouterAvailable()).as("Router must be available").isTrue();
+
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            authToken = keycloakManager.getMcpToken();
+        }
+    }
+
+    @DisplayName("Show details of a registered tool via CLI")
+    @Test
+    void shouldShowToolViaCli() {
+        routerClient.registerTool(HttpToolConfig.builder()
+                .name("cli-show-tool")
+                .description("Tool to show details via CLI")
+                .uri("https://httpbin.org/get")
+                .build());
+
+        CLIResult result = executeWithAuth("tools", "show", "--host", getRouterHost(), "cli-show-tool");
+
+        assertThat(result.isSuccess())
+                .as("CLI show command should succeed: %s", result.getCombinedOutput())
+                .isTrue();
+        assertThat(result.getCombinedOutput()).contains("cli-show-tool");
+    }
+
+    @DisplayName("CLI should return non-zero exit code for invalid subcommand")
+    @Test
+    void shouldFailWithInvalidSubcommand() {
+        CLIResult result = cliExecutor.execute("tools", "invalid-subcommand");
+
+        assertThat(result.isSuccess()).isFalse();
+    }
+
+    @DisplayName("CLI tools list returns empty output when no tools registered")
+    @Test
+    void shouldListEmptyTools() {
+        CLIResult result = executeWithAuth("tools", "list", "--host", getRouterHost());
+
+        assertThat(result.isSuccess())
+                .as("CLI list should succeed even with no tools: %s", result.getCombinedOutput())
+                .isTrue();
+    }
+
+    private String getRouterHost() {
+        return routerManager != null ? routerManager.getBaseUrl() : "http://localhost:8080";
+    }
+
+    private CLIResult executeWithAuth(String... args) {
+        if (authToken != null) {
+            String[] authArgs = new String[args.length + 2];
+            System.arraycopy(args, 0, authArgs, 0, args.length);
+            authArgs[args.length] = "--token";
+            authArgs[args.length + 1] = authToken;
+            return cliExecutor.execute(authArgs);
+        }
+        return cliExecutor.execute(args);
+    }
+}

--- a/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolErrorHandlingITCase.java
+++ b/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolErrorHandlingITCase.java
@@ -1,0 +1,127 @@
+package ai.wanaku.test.http;
+
+import java.util.Map;
+import org.testcontainers.containers.GenericContainer;
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.model.HttpToolConfig;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class HttpToolErrorHandlingITCase extends HttpCapabilityTestBase {
+
+    @SuppressWarnings("resource")
+    private static GenericContainer<?> httpbinContainer;
+
+    private static String httpbinBaseUrl;
+
+    @BeforeAll
+    static void startHttpbin() {
+        httpbinContainer = new GenericContainer<>("mccutchen/go-httpbin").withExposedPorts(8080);
+        httpbinContainer.start();
+        httpbinBaseUrl = "http://" + httpbinContainer.getHost() + ":" + httpbinContainer.getMappedPort(8080);
+    }
+
+    @AfterAll
+    static void stopHttpbin() {
+        if (httpbinContainer != null) {
+            httpbinContainer.stop();
+        }
+    }
+
+    @BeforeEach
+    void assumeFullStackAndMcpAvailable() {
+        assumeThat(isFullStackAvailable())
+                .as("Full stack required for error handling tests")
+                .isTrue();
+        assumeThat(isMcpClientAvailable()).as("MCP client must be connected").isTrue();
+    }
+
+    @DisplayName("Invoke tool pointing to unreachable endpoint and get error response")
+    @Test
+    void shouldHandleUnreachableEndpoint() {
+        HttpToolConfig config = HttpToolConfig.builder()
+                .name("unreachable-tool")
+                .description("Tool pointing to unreachable host")
+                .uri("http://192.0.2.1:9999/does-not-exist")
+                .build();
+
+        routerClient.registerTool(config);
+
+        try {
+            mcpClient
+                    .when()
+                    .toolsCall("unreachable-tool", Map.of(), response -> {
+                        assertThat(response.isError()).isTrue();
+                    })
+                    .thenAssertResults();
+        } catch (Exception e) {
+            assertThat(e.getMessage()).isNotNull();
+        }
+    }
+
+    @DisplayName("Invoke tool that returns HTTP 404 and get error in response")
+    @Test
+    void shouldHandleNotFoundEndpoint() {
+        HttpToolConfig config = HttpToolConfig.builder()
+                .name("not-found-tool")
+                .description("Tool pointing to 404 endpoint")
+                .uri(httpbinBaseUrl + "/status/404")
+                .build();
+
+        routerClient.registerTool(config);
+
+        mcpClient
+                .when()
+                .toolsCall("not-found-tool", Map.of(), response -> {
+                    String content = response.content().toString();
+                    assertThat(content).isNotEmpty();
+                })
+                .thenAssertResults();
+    }
+
+    @DisplayName("Invoke tool that returns HTTP 500 server error")
+    @Test
+    void shouldHandleServerError() {
+        HttpToolConfig config = HttpToolConfig.builder()
+                .name("server-error-tool")
+                .description("Tool pointing to 500 endpoint")
+                .uri(httpbinBaseUrl + "/status/500")
+                .build();
+
+        routerClient.registerTool(config);
+
+        mcpClient
+                .when()
+                .toolsCall("server-error-tool", Map.of(), response -> {
+                    String content = response.content().toString();
+                    assertThat(content).isNotEmpty();
+                })
+                .thenAssertResults();
+    }
+
+    @DisplayName("Invoke tool with empty response body from server")
+    @Test
+    void shouldHandleEmptyResponse() {
+        HttpToolConfig config = HttpToolConfig.builder()
+                .name("empty-response-tool")
+                .description("Tool pointing to endpoint that returns 204")
+                .uri(httpbinBaseUrl + "/status/204")
+                .build();
+
+        routerClient.registerTool(config);
+
+        mcpClient
+                .when()
+                .toolsCall("empty-response-tool", Map.of(), response -> {
+                    assertThat(response.content()).isNotNull();
+                })
+                .thenAssertResults();
+    }
+}

--- a/mcp-forwarding-tests/pom.xml
+++ b/mcp-forwarding-tests/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>ai.wanaku.tests</groupId>
+        <artifactId>wanaku-tests</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>mcp-forwarding-tests</artifactId>
+    <packaging>jar</packaging>
+
+    <name>Wanaku MCP Forwarding Tests</name>
+    <description>Integration tests for Wanaku MCP-to-MCP bridge forwarding</description>
+
+    <dependencies>
+        <!-- Test Common Module -->
+        <dependency>
+            <groupId>ai.wanaku.tests</groupId>
+            <artifactId>test-common</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Quarkus Test -->
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-junit5</artifactId>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.jboss.slf4j</groupId>
+                    <artifactId>slf4j-jboss-logmanager</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!-- JUnit 5 -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- AssertJ -->
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Awaitility -->
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <!-- Logging -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <configuration>
+                    <runOrder>random</runOrder>
+                    <systemPropertyVariables>
+                        <wanaku.test.artifacts.dir>${project.basedir}/../artifacts</wanaku.test.artifacts.dir>
+                    </systemPropertyVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingBasicITCase.java
+++ b/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingBasicITCase.java
@@ -1,0 +1,84 @@
+package ai.wanaku.test.forward;
+
+import java.util.List;
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.client.ForwardsClient;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class McpForwardingBasicITCase extends McpForwardingTestBase {
+
+    @BeforeEach
+    void assumeInfrastructureAvailable() {
+        assumeThat(isRouterAvailable()).as("Router must be available").isTrue();
+        assumeThat(isTargetRouterAvailable())
+                .as("Target router must be available for forwarding tests")
+                .isTrue();
+        assumeThat(testNamespaceId).as("Test namespace must be available").isNotNull();
+    }
+
+    private boolean tryAddForward(String name, String address) {
+        try {
+            forwardsClient.add(name, address, testNamespaceId);
+            return true;
+        } catch (ForwardsClient.ForwardsClientException e) {
+            return false;
+        }
+    }
+
+    @DisplayName("Add a forward to the target MCP server")
+    @Test
+    void shouldAddForward() {
+        boolean added = tryAddForward("test-forward", getTargetMcpUrl());
+        assumeThat(added)
+                .as("Router must accept the forward target (validates connectivity)")
+                .isTrue();
+
+        assertThat(forwardsClient.exists("test-forward")).isTrue();
+    }
+
+    @DisplayName("List forwards returns a valid response")
+    @Test
+    void shouldListForwards() {
+        List<JsonNode> forwards = forwardsClient.list();
+
+        assertThat(forwards).isNotNull();
+    }
+
+    @DisplayName("Remove a forward and verify it no longer exists")
+    @Test
+    void shouldRemoveForward() {
+        boolean added = tryAddForward("fwd-to-remove", getTargetMcpUrl());
+        assumeThat(added).as("Forward must be added before removal").isTrue();
+
+        boolean removed = forwardsClient.remove("fwd-to-remove");
+
+        assertThat(removed).isTrue();
+        assertThat(forwardsClient.exists("fwd-to-remove")).isFalse();
+    }
+
+    @DisplayName("Return false when removing a non-existent forward")
+    @Test
+    void shouldReturnFalseWhenRemovingNonexistentForward() {
+        boolean removed = forwardsClient.remove("nonexistent-forward");
+
+        assertThat(removed).isFalse();
+    }
+
+    @DisplayName("Refresh a forward without error")
+    @Test
+    void shouldRefreshForwards() {
+        boolean added = tryAddForward("refresh-test-fwd", getTargetMcpUrl());
+        assumeThat(added).as("Forward must be added before refresh").isTrue();
+
+        forwardsClient.refresh("refresh-test-fwd");
+
+        assertThat(forwardsClient.exists("refresh-test-fwd")).isTrue();
+    }
+}

--- a/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingErrorITCase.java
+++ b/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingErrorITCase.java
@@ -1,0 +1,54 @@
+package ai.wanaku.test.forward;
+
+import java.util.List;
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.client.ForwardsClient;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
+
+@QuarkusTest
+class McpForwardingErrorITCase extends McpForwardingTestBase {
+
+    @BeforeEach
+    void assumeInfrastructureAvailable() {
+        assumeThat(isRouterAvailable()).as("Router must be available").isTrue();
+        assumeThat(testNamespaceId).as("Test namespace must be available").isNotNull();
+    }
+
+    @DisplayName("Router rejects a forward pointing to an unreachable server")
+    @Test
+    void shouldRejectUnreachableServerForward() {
+        try {
+            forwardsClient.add("unreachable-fwd", "http://localhost:1/mcp/", testNamespaceId);
+            assertThat(forwardsClient.exists("unreachable-fwd")).isTrue();
+        } catch (ForwardsClient.ForwardsClientException e) {
+            assertThat(e.getMessage()).contains("500");
+        }
+    }
+
+    @DisplayName("Adding a forward with a valid target succeeds")
+    @Test
+    void shouldAddForwardWithValidTarget() {
+        try {
+            forwardsClient.add("valid-fwd", routerManager.getBaseUrl() + "/mcp/", testNamespaceId);
+            assertThat(forwardsClient.exists("valid-fwd")).isTrue();
+        } catch (ForwardsClient.ForwardsClientException e) {
+            assumeThat(e.getMessage())
+                    .as("Router validates forward target connectivity")
+                    .doesNotContain("500");
+        }
+    }
+
+    @DisplayName("List forwards returns valid response even when empty")
+    @Test
+    void shouldListForwardsWhenEmpty() {
+        List<JsonNode> forwards = forwardsClient.list();
+
+        assertThat(forwards).isNotNull();
+    }
+}

--- a/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingErrorITCase.java
+++ b/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingErrorITCase.java
@@ -20,9 +20,9 @@ class McpForwardingErrorITCase extends McpForwardingTestBase {
         assumeThat(testNamespaceId).as("Test namespace must be available").isNotNull();
     }
 
-    @DisplayName("Router rejects a forward pointing to an unreachable server")
+    @DisplayName("Router handles a forward pointing to an unreachable server")
     @Test
-    void shouldRejectUnreachableServerForward() {
+    void shouldHandleUnreachableServerForward() {
         try {
             forwardsClient.add("unreachable-fwd", "http://localhost:1/mcp/", testNamespaceId);
             assertThat(forwardsClient.exists("unreachable-fwd")).isTrue();

--- a/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingTestBase.java
+++ b/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingTestBase.java
@@ -1,0 +1,146 @@
+package ai.wanaku.test.forward;
+
+import java.io.IOException;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ai.wanaku.test.base.BaseIntegrationTest;
+import ai.wanaku.test.client.ForwardsClient;
+import ai.wanaku.test.client.NamespaceClient;
+import ai.wanaku.test.client.RouterClient;
+import ai.wanaku.test.config.OidcCredentials;
+import ai.wanaku.test.config.TargetConfiguration;
+import ai.wanaku.test.managers.HttpCapabilityManager;
+import ai.wanaku.test.managers.RouterManager;
+import ai.wanaku.test.model.HttpToolConfig;
+import com.fasterxml.jackson.databind.JsonNode;
+
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.TestInfo;
+
+public abstract class McpForwardingTestBase extends BaseIntegrationTest {
+
+    private static final Logger LOG = LoggerFactory.getLogger(McpForwardingTestBase.class);
+
+    protected static RouterManager targetRouterManager;
+    protected static RouterClient targetRouterClient;
+    protected static HttpCapabilityManager targetHttpCapability;
+    protected ForwardsClient forwardsClient;
+    protected NamespaceClient namespaceClient;
+    protected String testNamespaceId;
+
+    @BeforeAll
+    static void startTargetRouter() throws IOException {
+        if (config == null || config.getRouterJarPath() == null) {
+            LOG.warn("Router JAR not available, skipping target router setup");
+            return;
+        }
+
+        targetRouterManager = new RouterManager(config);
+        targetRouterManager.prepare();
+        targetRouterManager.start("forwarding-target");
+
+        String accessToken = null;
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            accessToken = keycloakManager.getMcpToken();
+        }
+
+        targetRouterClient = new RouterClient(targetRouterManager.getBaseUrl(), accessToken);
+
+        if (config.getHttpToolServiceJarPath() != null
+                && config.getHttpToolServiceJarPath().toFile().exists()) {
+            OidcCredentials oidcCredentials = null;
+            if (keycloakManager != null && keycloakManager.isRunning()) {
+                oidcCredentials = keycloakManager.getServiceCredentials();
+            }
+
+            targetHttpCapability = new HttpCapabilityManager(config);
+            targetHttpCapability.prepare(new TargetConfiguration(
+                    "localhost",
+                    targetRouterManager.getHttpPort(),
+                    targetRouterManager.getGrpcPort(),
+                    oidcCredentials));
+            targetHttpCapability.start("forwarding-target-http");
+
+            targetRouterClient.registerTool(HttpToolConfig.builder()
+                    .name("forwarded-tool")
+                    .description("A tool available via forwarding")
+                    .uri("https://httpbin.org/get")
+                    .build());
+        }
+    }
+
+    @BeforeEach
+    void setupForwardingClients(TestInfo testInfo) {
+        if (routerManager != null && routerManager.isRunning()) {
+            String accessToken = null;
+            if (keycloakManager != null && keycloakManager.isRunning()) {
+                accessToken = keycloakManager.getMcpToken();
+            }
+            forwardsClient = new ForwardsClient(routerManager.getBaseUrl(), accessToken);
+            namespaceClient = new NamespaceClient(routerManager.getBaseUrl(), accessToken);
+            try {
+                List<JsonNode> namespaces = namespaceClient.list();
+                for (JsonNode ns : namespaces) {
+                    if (ns.has("name") && "fwd-test-ns".equals(ns.get("name").asText())) {
+                        testNamespaceId = ns.get("id").asText();
+                        break;
+                    }
+                }
+                if (testNamespaceId == null) {
+                    testNamespaceId = namespaceClient.create("fwd-test-ns", "/fwd-test-ns");
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to setup test namespace: {}", e.getMessage());
+            }
+        }
+    }
+
+    @AfterEach
+    void cleanupForwards() {
+        if (forwardsClient != null) {
+            try {
+                forwardsClient.clearAll();
+            } catch (Exception e) {
+                LOG.warn("Failed to clear forwards: {}", e.getMessage());
+            }
+        }
+    }
+
+    @AfterAll
+    static void stopTargetRouter() {
+        if (targetHttpCapability != null) {
+            try {
+                targetHttpCapability.stop();
+            } catch (Exception e) {
+                LOG.warn("Failed to stop target HTTP capability: {}", e.getMessage());
+            }
+            targetHttpCapability = null;
+        }
+        if (targetRouterManager != null) {
+            try {
+                targetRouterManager.stop();
+            } catch (Exception e) {
+                LOG.warn("Failed to stop target router: {}", e.getMessage());
+            }
+            targetRouterManager = null;
+        }
+        targetRouterClient = null;
+    }
+
+    protected boolean isTargetRouterAvailable() {
+        return targetRouterManager != null && targetRouterManager.isRunning();
+    }
+
+    protected String getTargetMcpUrl() {
+        return targetRouterManager.getBaseUrl() + "/mcp/";
+    }
+
+    @Override
+    protected String getLogProfile() {
+        return "mcp-forwarding";
+    }
+}

--- a/mcp-forwarding-tests/src/test/resources/wanaku-realm.json
+++ b/mcp-forwarding-tests/src/test/resources/wanaku-realm.json
@@ -1,0 +1,2723 @@
+{
+  "id": "bd06421e-905a-4998-b620-21d16e53c3bd",
+  "realm": "wanaku",
+  "notBefore": 0,
+  "defaultSignatureAlgorithm": "RS256",
+  "revokeRefreshToken": false,
+  "refreshTokenMaxReuse": 0,
+  "accessTokenLifespan": 300,
+  "accessTokenLifespanForImplicitFlow": 900,
+  "ssoSessionIdleTimeout": 1800,
+  "ssoSessionMaxLifespan": 36000,
+  "ssoSessionIdleTimeoutRememberMe": 0,
+  "ssoSessionMaxLifespanRememberMe": 0,
+  "offlineSessionIdleTimeout": 2592000,
+  "offlineSessionMaxLifespanEnabled": false,
+  "offlineSessionMaxLifespan": 5184000,
+  "clientSessionIdleTimeout": 0,
+  "clientSessionMaxLifespan": 0,
+  "clientOfflineSessionIdleTimeout": 0,
+  "clientOfflineSessionMaxLifespan": 0,
+  "accessCodeLifespan": 60,
+  "accessCodeLifespanUserAction": 300,
+  "accessCodeLifespanLogin": 1800,
+  "actionTokenGeneratedByAdminLifespan": 43200,
+  "actionTokenGeneratedByUserLifespan": 300,
+  "oauth2DeviceCodeLifespan": 600,
+  "oauth2DevicePollingInterval": 5,
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": true,
+  "registrationEmailAsUsername": false,
+  "rememberMe": false,
+  "verifyEmail": false,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "resetPasswordAllowed": false,
+  "editUsernameAllowed": true,
+  "bruteForceProtected": false,
+  "permanentLockout": false,
+  "maxTemporaryLockouts": 0,
+  "bruteForceStrategy": "MULTIPLE",
+  "maxFailureWaitSeconds": 900,
+  "minimumQuickLoginWaitSeconds": 60,
+  "waitIncrementSeconds": 60,
+  "quickLoginCheckMilliSeconds": 1000,
+  "maxDeltaTimeSeconds": 43200,
+  "failureFactor": 30,
+  "roles": {
+    "realm": [
+      {
+        "id": "0d22bc69-c630-49e3-86ec-267bab17b14b",
+        "name": "uma_authorization",
+        "description": "${role_uma_authorization}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "bd06421e-905a-4998-b620-21d16e53c3bd",
+        "attributes": {}
+      },
+      {
+        "id": "a7ed6f24-635d-4525-a38e-cd9c94f65d88",
+        "name": "default-roles-wanaku",
+        "description": "${role_default-roles}",
+        "composite": true,
+        "composites": {
+          "realm": [
+            "offline_access",
+            "uma_authorization"
+          ],
+          "client": {
+            "account": [
+              "manage-account",
+              "view-profile"
+            ]
+          }
+        },
+        "clientRole": false,
+        "containerId": "bd06421e-905a-4998-b620-21d16e53c3bd",
+        "attributes": {}
+      },
+      {
+        "id": "3cf74d5f-98e0-4e9d-85f0-8db52b27bee0",
+        "name": "offline_access",
+        "description": "${role_offline-access}",
+        "composite": false,
+        "clientRole": false,
+        "containerId": "bd06421e-905a-4998-b620-21d16e53c3bd",
+        "attributes": {}
+      }
+    ],
+    "client": {
+      "realm-management": [
+        {
+          "id": "452962e9-c64d-444f-b778-d59ef66ba3bb",
+          "name": "query-groups",
+          "description": "${role_query-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "92728100-1602-4e5c-8ee4-5925032c9065",
+          "name": "manage-users",
+          "description": "${role_manage-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "ef1639ee-3e38-4bc3-8143-244b376fcfd2",
+          "name": "manage-authorization",
+          "description": "${role_manage-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "cbaecd6d-5557-46ef-90e5-cc18619776e2",
+          "name": "realm-admin",
+          "description": "${role_realm-admin}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-groups",
+                "manage-users",
+                "manage-authorization",
+                "view-realm",
+                "view-events",
+                "manage-clients",
+                "query-realms",
+                "view-authorization",
+                "create-client",
+                "manage-realm",
+                "view-identity-providers",
+                "query-clients",
+                "impersonation",
+                "manage-identity-providers",
+                "manage-events",
+                "query-users",
+                "view-users",
+                "view-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "f1c16762-3659-4290-99d9-b7235ce63815",
+          "name": "view-realm",
+          "description": "${role_view-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "5c5fc853-11f2-4967-bb3a-a1d35656a6aa",
+          "name": "view-events",
+          "description": "${role_view-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "a6f2a6b3-fe71-473f-86ae-8d582f61e97d",
+          "name": "manage-clients",
+          "description": "${role_manage-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "20955d6b-90ff-4ad8-a409-68b8146abee5",
+          "name": "query-realms",
+          "description": "${role_query-realms}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "fb9c992e-fb50-45f0-8a7f-992d3f2a1f0b",
+          "name": "view-authorization",
+          "description": "${role_view-authorization}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "7522de19-5801-4aff-8b0b-e328cdfa996f",
+          "name": "create-client",
+          "description": "${role_create-client}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "dd56bfba-ec12-4626-b1b5-a69c0b043057",
+          "name": "manage-realm",
+          "description": "${role_manage-realm}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "b85cb53a-3efb-4911-a270-c698e6e73a2f",
+          "name": "view-identity-providers",
+          "description": "${role_view-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "c12bd3b6-60a1-4f35-aed9-3fd11c6e7fc0",
+          "name": "impersonation",
+          "description": "${role_impersonation}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "c44716dd-7c73-4d36-97a2-6ae98977dbb3",
+          "name": "manage-identity-providers",
+          "description": "${role_manage-identity-providers}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "319ae117-aea3-4783-a19d-14eb291aa02a",
+          "name": "query-clients",
+          "description": "${role_query-clients}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "543e65e8-753b-49c2-8475-d04bcb09a4e9",
+          "name": "manage-events",
+          "description": "${role_manage-events}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "9c74e32d-e157-4d73-bb9c-ca8b7793a0b1",
+          "name": "query-users",
+          "description": "${role_query-users}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "79ea100f-5d9f-489f-999e-1744a8a9e16a",
+          "name": "view-users",
+          "description": "${role_view-users}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-groups",
+                "query-users"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        },
+        {
+          "id": "183edf19-f4bf-4306-bf3a-d47313377714",
+          "name": "view-clients",
+          "description": "${role_view-clients}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "realm-management": [
+                "query-clients"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+          "attributes": {}
+        }
+      ],
+      "wanaku-service": [
+        {
+          "id": "8462e78a-85d8-47af-aa0b-b3d8cacd2a1d",
+          "name": "capabilities-service",
+          "description": "Capabilities services",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "102929ec-264a-4acb-8111-970d62a112fb",
+          "attributes": {}
+        }
+      ],
+      "mcp-client": [],
+      "wanaku-mcp-router": [],
+      "security-admin-console": [],
+      "admin-cli": [],
+      "account-console": [],
+      "broker": [
+        {
+          "id": "1699a0cf-0e49-421b-b01e-e822d0fd258b",
+          "name": "read-token",
+          "description": "${role_read-token}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "3462dcd6-64a8-4fbf-950e-17b3283370d2",
+          "attributes": {}
+        }
+      ],
+      "account": [
+        {
+          "id": "4a3d92ec-a563-4925-a602-cfa5b291b41b",
+          "name": "view-groups",
+          "description": "${role_view-groups}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "5b11061f-8bbc-4694-bc91-0b1dbdeda952",
+          "name": "view-consent",
+          "description": "${role_view-consent}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "c71b475b-26b2-48d4-b019-fe62b503c8e1",
+          "name": "manage-account",
+          "description": "${role_manage-account}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "manage-account-links"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "ecddd740-d93b-44bf-911c-f56cdbe6b85a",
+          "name": "manage-account-links",
+          "description": "${role_manage-account-links}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "95af1e3b-d06a-4765-81c6-6fe774824164",
+          "name": "manage-consent",
+          "description": "${role_manage-consent}",
+          "composite": true,
+          "composites": {
+            "client": {
+              "account": [
+                "view-consent"
+              ]
+            }
+          },
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "b89d4a45-dacd-4efb-ad9f-a1149f9e1282",
+          "name": "view-applications",
+          "description": "${role_view-applications}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "3f2fd48b-f2e7-4f5e-9d81-73fa43f0edd6",
+          "name": "delete-account",
+          "description": "${role_delete-account}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        },
+        {
+          "id": "3304401d-6f0c-4c18-a501-9b75f207edae",
+          "name": "view-profile",
+          "description": "${role_view-profile}",
+          "composite": false,
+          "clientRole": true,
+          "containerId": "7c33d531-813f-4850-9cf5-cafef1799f63",
+          "attributes": {}
+        }
+      ]
+    }
+  },
+  "groups": [],
+  "defaultRole": {
+    "id": "a7ed6f24-635d-4525-a38e-cd9c94f65d88",
+    "name": "default-roles-wanaku",
+    "description": "${role_default-roles}",
+    "composite": true,
+    "clientRole": false,
+    "containerId": "bd06421e-905a-4998-b620-21d16e53c3bd"
+  },
+  "requiredCredentials": [
+    "password"
+  ],
+  "otpPolicyType": "totp",
+  "otpPolicyAlgorithm": "HmacSHA1",
+  "otpPolicyInitialCounter": 0,
+  "otpPolicyDigits": 6,
+  "otpPolicyLookAheadWindow": 1,
+  "otpPolicyPeriod": 30,
+  "otpPolicyCodeReusable": false,
+  "otpSupportedApplications": [
+    "totpAppFreeOTPName",
+    "totpAppGoogleName",
+    "totpAppMicrosoftAuthenticatorName"
+  ],
+  "localizationTexts": {},
+  "webAuthnPolicyRpEntityName": "keycloak",
+  "webAuthnPolicySignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyRpId": "",
+  "webAuthnPolicyAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyRequireResidentKey": "not specified",
+  "webAuthnPolicyUserVerificationRequirement": "not specified",
+  "webAuthnPolicyCreateTimeout": 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyAcceptableAaguids": [],
+  "webAuthnPolicyExtraOrigins": [],
+  "webAuthnPolicyPasswordlessRpEntityName": "keycloak",
+  "webAuthnPolicyPasswordlessSignatureAlgorithms": [
+    "ES256",
+    "RS256"
+  ],
+  "webAuthnPolicyPasswordlessRpId": "",
+  "webAuthnPolicyPasswordlessAttestationConveyancePreference": "not specified",
+  "webAuthnPolicyPasswordlessAuthenticatorAttachment": "not specified",
+  "webAuthnPolicyPasswordlessRequireResidentKey": "not specified",
+  "webAuthnPolicyPasswordlessUserVerificationRequirement": "not specified",
+  "webAuthnPolicyPasswordlessCreateTimeout": 0,
+  "webAuthnPolicyPasswordlessAvoidSameAuthenticatorRegister": false,
+  "webAuthnPolicyPasswordlessAcceptableAaguids": [],
+  "webAuthnPolicyPasswordlessExtraOrigins": [],
+  "users": [
+    {
+      "id": "aa5a46fe-1082-4fcc-b546-da670324fa0f",
+      "username": "service-account-wanaku-service",
+      "emailVerified": false,
+      "enabled": true,
+      "createdTimestamp": 1753779042609,
+      "totp": false,
+      "serviceAccountClientId": "wanaku-service",
+      "disableableCredentialTypes": [],
+      "requiredActions": [],
+      "realmRoles": [
+        "default-roles-wanaku"
+      ],
+      "notBefore": 0,
+      "groups": []
+    }
+  ],
+  "scopeMappings": [
+    {
+      "clientScope": "offline_access",
+      "roles": [
+        "offline_access"
+      ]
+    }
+  ],
+  "clientScopeMappings": {
+    "account": [
+      {
+        "client": "account-console",
+        "roles": [
+          "manage-account",
+          "view-groups"
+        ]
+      }
+    ]
+  },
+  "clients": [
+    {
+      "id": "7c33d531-813f-4850-9cf5-cafef1799f63",
+      "clientId": "account",
+      "name": "${client_account}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/wanaku/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/wanaku/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "182ad08c-05c3-4cf2-a53d-b584c9ce958c",
+      "clientId": "account-console",
+      "name": "${client_account-console}",
+      "rootUrl": "${authBaseUrl}",
+      "baseUrl": "/realms/wanaku/account/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/realms/wanaku/account/*"
+      ],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "f571110d-ca10-484d-8a84-e90281918f37",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "65ca7d23-6cb5-44d6-bc68-1ea9be2b5e2c",
+      "clientId": "admin-cli",
+      "name": "${client_admin-cli}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": false,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": true,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "3462dcd6-64a8-4fbf-950e-17b3283370d2",
+      "clientId": "broker",
+      "name": "${client_broker}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "a650d880-5904-4632-8f22-bac8e6db358f",
+      "clientId": "mcp-client",
+      "name": "MCP Clients",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "http://localhost:8080/*",
+        "http://localhost:6274/*"
+      ],
+      "webOrigins": [
+        "*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "standard.token.exchange.enabled": "false",
+        "post.logout.redirect.uris": "+",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "backchannel.logout.revoke.offline.tokens": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "wanaku-mcp-client",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "d76e0ce5-9dc4-455b-91b3-2d0cdb1fd8c1",
+      "clientId": "realm-management",
+      "name": "${client_realm-management}",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [],
+      "webOrigins": [],
+      "notBefore": 0,
+      "bearerOnly": true,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": false,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "true"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": false,
+      "nodeReRegistrationTimeout": 0,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "aca78c90-a649-40b5-b418-e76f8a5d9a3e",
+      "clientId": "security-admin-console",
+      "name": "${client_security-admin-console}",
+      "rootUrl": "${authAdminUrl}",
+      "baseUrl": "/admin/wanaku/console/",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "/admin/wanaku/console/*"
+      ],
+      "webOrigins": [
+        "+"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": false,
+      "protocol": "openid-connect",
+      "attributes": {
+        "realm_client": "false",
+        "client.use.lightweight.access.token.enabled": "true",
+        "post.logout.redirect.uris": "+",
+        "pkce.code.challenge.method": "S256"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": 0,
+      "protocolMappers": [
+        {
+          "id": "bbe9caa0-5a9a-4ccc-9c33-af55013aa671",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ],
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "b340aa29-417b-4988-ab92-edfd12d8d1e8",
+      "clientId": "wanaku-mcp-router",
+      "name": "Wanaku MCP Router",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "redirectUris": [
+        "http://localhost:8080/*",
+        "*"
+      ],
+      "webOrigins": [
+        "http://localhost:8080/*",
+        "*"
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": false,
+      "publicClient": true,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "request.object.signature.alg": "any",
+        "post.logout.redirect.uris": "*",
+        "frontchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "use.jwks.url": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "use.refresh.tokens": "true",
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "client_credentials.use_refresh_token": "false",
+        "require.pushed.authorization.requests": "false",
+        "request.object.encryption.enc": "any",
+        "client.secret.creation.time": "1753691197",
+        "request.object.encryption.alg": "any",
+        "client.introspection.response.allow.jwt.claim.enabled": "false",
+        "standard.token.exchange.enabled": "false",
+        "login_theme": "keycloak",
+        "client.use.lightweight.access.token.enabled": "false",
+        "request.object.required": "not required",
+        "access.token.header.type.rfc9068": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "acr.loa.map": "{}",
+        "display.on.consent.screen": "false",
+        "token.response.type.bearer.lower-case": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    },
+    {
+      "id": "102929ec-264a-4acb-8111-970d62a112fb",
+      "clientId": "wanaku-service",
+      "name": "Wanaku Capabilities Services",
+      "description": "",
+      "rootUrl": "",
+      "adminUrl": "",
+      "baseUrl": "",
+      "surrogateAuthRequired": false,
+      "enabled": true,
+      "alwaysDisplayInConsole": false,
+      "clientAuthenticatorType": "client-secret",
+      "secret": "**********",
+      "redirectUris": [
+        ""
+      ],
+      "webOrigins": [
+        ""
+      ],
+      "notBefore": 0,
+      "bearerOnly": false,
+      "consentRequired": false,
+      "standardFlowEnabled": true,
+      "implicitFlowEnabled": false,
+      "directAccessGrantsEnabled": false,
+      "serviceAccountsEnabled": true,
+      "publicClient": false,
+      "frontchannelLogout": true,
+      "protocol": "openid-connect",
+      "attributes": {
+        "client.secret.creation.time": "1753706698",
+        "request.object.signature.alg": "any",
+        "request.object.encryption.alg": "any",
+        "client.introspection.response.allow.jwt.claim.enabled": "false",
+        "standard.token.exchange.enabled": "false",
+        "frontchannel.logout.session.required": "true",
+        "oauth2.device.authorization.grant.enabled": "false",
+        "use.jwks.url": "false",
+        "backchannel.logout.revoke.offline.tokens": "false",
+        "use.refresh.tokens": "true",
+        "realm_client": "false",
+        "oidc.ciba.grant.enabled": "false",
+        "client.use.lightweight.access.token.enabled": "false",
+        "backchannel.logout.session.required": "true",
+        "request.object.required": "not required",
+        "client_credentials.use_refresh_token": "false",
+        "access.token.header.type.rfc9068": "false",
+        "tls.client.certificate.bound.access.tokens": "false",
+        "require.pushed.authorization.requests": "false",
+        "acr.loa.map": "{}",
+        "display.on.consent.screen": "false",
+        "request.object.encryption.enc": "any",
+        "token.response.type.bearer.lower-case": "false"
+      },
+      "authenticationFlowBindingOverrides": {},
+      "fullScopeAllowed": true,
+      "nodeReRegistrationTimeout": -1,
+      "defaultClientScopes": [
+        "service_account",
+        "web-origins",
+        "acr",
+        "roles",
+        "profile",
+        "basic",
+        "email"
+      ],
+      "optionalClientScopes": [
+        "address",
+        "phone",
+        "offline_access",
+        "organization",
+        "microprofile-jwt"
+      ]
+    }
+  ],
+  "clientScopes": [
+    {
+      "id": "a431880f-1c93-424d-b0a9-880fc530b84c",
+      "name": "phone",
+      "description": "OpenID Connect built-in scope: phone",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${phoneScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "5a8f3147-1a16-4f13-b03d-f3596f0d541b",
+          "name": "phone number",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumber",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "546b1dca-3b3a-4a4e-b624-3cf32b856573",
+          "name": "phone number verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "phoneNumberVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "phone_number_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "0e8d5737-3173-4376-acae-102ef676c6be",
+      "name": "roles",
+      "description": "OpenID Connect scope for add user roles to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "${rolesScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "6601911c-edf3-44f3-b38e-82e1db171d5c",
+          "name": "realm roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "realm_access.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "40eb024e-8eb5-46a6-b3b8-6ec850326916",
+          "name": "client roles",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-client-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute": "foo",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "resource_access.${client_id}.roles",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        },
+        {
+          "id": "0794dbd7-2153-4d94-861a-8fd4448a429b",
+          "name": "audience resolve",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-resolve-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "2dedbab1-8d8f-4b31-bd31-1f7daae26b2b",
+      "name": "offline_access",
+      "description": "OpenID Connect built-in scope: offline_access",
+      "protocol": "openid-connect",
+      "attributes": {
+        "consent.screen.text": "${offlineAccessScopeConsentText}",
+        "display.on.consent.screen": "true"
+      }
+    },
+    {
+      "id": "e57a0bac-02f6-447c-8549-14175f0eff8e",
+      "name": "service_account",
+      "description": "Specific scope for a client enabled for service accounts",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "5d912750-1664-4dd2-9b1b-5ada490319a9",
+          "name": "Client ID",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "client_id",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "client_id",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3863e337-1909-41e6-82e1-09c85c326bbd",
+          "name": "Client Host",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientHost",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientHost",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0ccc9405-3e88-4758-8671-0745d59613a8",
+          "name": "Client IP Address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "clientAddress",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "clientAddress",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "a82c2f06-78bb-4a8f-8768-4f8005d4833f",
+      "name": "wanaku-mcp-client",
+      "description": "",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "true",
+        "gui.order": "",
+        "consent.screen.text": ""
+      },
+      "protocolMappers": [
+        {
+          "id": "68748dc4-6dc6-4045-b645-0727b7bbd746",
+          "name": "wanaku-mcp-client-audience",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-audience-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "false",
+            "lightweight.claim": "false",
+            "access.token.claim": "true",
+            "introspection.token.claim": "true",
+            "included.custom.audience": "wanaku-mcp-client"
+          }
+        }
+      ]
+    },
+    {
+      "id": "15c1634a-7093-47b1-aad6-892b4d398c08",
+      "name": "profile",
+      "description": "OpenID Connect built-in scope: profile",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${profileScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "5abaa686-bcc3-4795-955e-9e2f076361bb",
+          "name": "username",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "preferred_username",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "9d226f62-1d45-4fe2-98db-ff7ec8137c63",
+          "name": "website",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "website",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "website",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "75e9b82d-1ddf-47e4-abdb-a8ad3350c51d",
+          "name": "middle name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "middleName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "middle_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "cb0efcfe-43d6-4c5b-89f3-6e0da2fceb55",
+          "name": "picture",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "picture",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "picture",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "db5a9cbc-768e-49c3-9610-db5f8adc69ac",
+          "name": "birthdate",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "birthdate",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "birthdate",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "0629c8ea-f1bf-4eb3-8726-05e532bbd55c",
+          "name": "zoneinfo",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "zoneinfo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "zoneinfo",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d48c4bd9-f16d-49aa-821b-81b8f7754071",
+          "name": "updated at",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "updatedAt",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "updated_at",
+            "jsonType.label": "long"
+          }
+        },
+        {
+          "id": "13638c7e-ad52-47d2-b192-a3f0a6a4131c",
+          "name": "profile",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "profile",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "profile",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "bde4c699-40c4-4c25-9e7f-f197c8b5bcc8",
+          "name": "given name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "firstName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "given_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "b6a782d7-b432-4235-88ad-0a476055634b",
+          "name": "nickname",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "nickname",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "nickname",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "87caaf0c-13af-476d-91fe-aea1bb543a6e",
+          "name": "gender",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "gender",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "gender",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "d0793bb7-78ae-474c-89de-9833db98db81",
+          "name": "full name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-full-name-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "userinfo.token.claim": "true"
+          }
+        },
+        {
+          "id": "1cb01ccc-d55b-4769-8ec8-a2364d3a6e1b",
+          "name": "family name",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "lastName",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "family_name",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "6bf23463-3d09-4efa-a00a-5017e68cf927",
+          "name": "locale",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "locale",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "locale",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "e16038dd-e2ba-407d-b4ed-b71b4468b1ab",
+      "name": "basic",
+      "description": "OpenID Connect scope for add all basic claims to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "f4680942-98ac-4473-a7a5-f3478a32dd22",
+          "name": "sub",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-sub-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        },
+        {
+          "id": "9f22d080-a8a0-4d94-8d15-35ac17074470",
+          "name": "auth_time",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usersessionmodel-note-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.session.note": "AUTH_TIME",
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "auth_time",
+            "jsonType.label": "long"
+          }
+        }
+      ]
+    },
+    {
+      "id": "6b7fb08f-37d2-436c-88f4-85d90828b2c2",
+      "name": "role_list",
+      "description": "SAML role list",
+      "protocol": "saml",
+      "attributes": {
+        "consent.screen.text": "${samlRoleListScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "6913c74c-2117-4261-8683-92ae0f4f58ce",
+          "name": "role list",
+          "protocol": "saml",
+          "protocolMapper": "saml-role-list-mapper",
+          "consentRequired": false,
+          "config": {
+            "single": "false",
+            "attribute.nameformat": "Basic",
+            "attribute.name": "Role"
+          }
+        }
+      ]
+    },
+    {
+      "id": "c94a6819-8561-402b-af6f-70d48fe8e7ce",
+      "name": "address",
+      "description": "OpenID Connect built-in scope: address",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${addressScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "77ab6f8d-d2f6-4212-ab3c-bc6cacb321d5",
+          "name": "address",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-address-mapper",
+          "consentRequired": false,
+          "config": {
+            "user.attribute.formatted": "formatted",
+            "user.attribute.country": "country",
+            "introspection.token.claim": "true",
+            "user.attribute.postal_code": "postal_code",
+            "userinfo.token.claim": "true",
+            "user.attribute.street": "street",
+            "id.token.claim": "true",
+            "user.attribute.region": "region",
+            "access.token.claim": "true",
+            "user.attribute.locality": "locality"
+          }
+        }
+      ]
+    },
+    {
+      "id": "7e737e40-7b80-44c8-bdfb-22af72a257c3",
+      "name": "acr",
+      "description": "OpenID Connect scope for add acr (authentication context class reference) to the token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "b4d57ab0-4e0d-4ebd-9430-d82a9b05b74f",
+          "name": "acr loa level",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-acr-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "a1253151-e390-47f8-94de-5715fd65f24f",
+      "name": "email",
+      "description": "OpenID Connect built-in scope: email",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${emailScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "7dee4a53-27ca-4f18-bdb8-8cccbeb0f6d9",
+          "name": "email",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "email",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "46539880-af55-4913-b94b-6896349be64a",
+          "name": "email verified",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-property-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "emailVerified",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "email_verified",
+            "jsonType.label": "boolean"
+          }
+        }
+      ]
+    },
+    {
+      "id": "141583d0-c12b-46b9-aab3-2b0180b14587",
+      "name": "organization",
+      "description": "Additional claims about the organization a subject belongs to",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "consent.screen.text": "${organizationScopeConsentText}",
+        "display.on.consent.screen": "true"
+      },
+      "protocolMappers": [
+        {
+          "id": "4fc32589-ea6e-4c5c-bb7e-6980058941fd",
+          "name": "organization",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {
+            "id.token.claim": "true",
+            "introspection.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "organization",
+            "jsonType.label": "String",
+            "multivalued": "true"
+          }
+        }
+      ]
+    },
+    {
+      "id": "ce13e423-8d5e-42ed-ad78-c09b7ce1b2fa",
+      "name": "microprofile-jwt",
+      "description": "Microprofile - JWT built-in scope",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "true",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "6ea8070c-5767-41af-845d-e78d8f49f9c3",
+          "name": "upn",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-attribute-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "userinfo.token.claim": "true",
+            "user.attribute": "username",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "upn",
+            "jsonType.label": "String"
+          }
+        },
+        {
+          "id": "3ed97d16-9d01-490c-a1f1-a9896f4e4505",
+          "name": "groups",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-usermodel-realm-role-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "multivalued": "true",
+            "user.attribute": "foo",
+            "id.token.claim": "true",
+            "access.token.claim": "true",
+            "claim.name": "groups",
+            "jsonType.label": "String"
+          }
+        }
+      ]
+    },
+    {
+      "id": "e34f7886-9733-4838-8dda-57fcaf8c4c6e",
+      "name": "saml_organization",
+      "description": "Organization Membership",
+      "protocol": "saml",
+      "attributes": {
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "1ea4941f-83e3-46d3-b759-2ef9e144781e",
+          "name": "organization",
+          "protocol": "saml",
+          "protocolMapper": "saml-organization-membership-mapper",
+          "consentRequired": false,
+          "config": {}
+        }
+      ]
+    },
+    {
+      "id": "7f21259a-6bb5-48c4-829e-271b66131085",
+      "name": "web-origins",
+      "description": "OpenID Connect scope for add allowed web origins to the access token",
+      "protocol": "openid-connect",
+      "attributes": {
+        "include.in.token.scope": "false",
+        "consent.screen.text": "",
+        "display.on.consent.screen": "false"
+      },
+      "protocolMappers": [
+        {
+          "id": "2cf8c67c-ec1a-4289-b1e9-3d1a66df35b0",
+          "name": "allowed web origins",
+          "protocol": "openid-connect",
+          "protocolMapper": "oidc-allowed-origins-mapper",
+          "consentRequired": false,
+          "config": {
+            "introspection.token.claim": "true",
+            "access.token.claim": "true"
+          }
+        }
+      ]
+    }
+  ],
+  "defaultDefaultClientScopes": [
+    "role_list",
+    "saml_organization",
+    "profile",
+    "email",
+    "roles",
+    "web-origins",
+    "acr",
+    "basic"
+  ],
+  "defaultOptionalClientScopes": [
+    "offline_access",
+    "address",
+    "phone",
+    "microprofile-jwt",
+    "organization",
+    "wanaku-mcp-client"
+  ],
+  "browserSecurityHeaders": {
+    "contentSecurityPolicyReportOnly": "",
+    "xContentTypeOptions": "nosniff",
+    "referrerPolicy": "no-referrer",
+    "xRobotsTag": "none",
+    "xFrameOptions": "SAMEORIGIN",
+    "contentSecurityPolicy": "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "strictTransportSecurity": "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer": {},
+  "loginTheme": "keycloak.v2",
+  "accountTheme": "keycloak.v3",
+  "adminTheme": "",
+  "emailTheme": "",
+  "eventsEnabled": false,
+  "eventsListeners": [
+    "jboss-logging"
+  ],
+  "enabledEventTypes": [],
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "identityProviders": [],
+  "identityProviderMappers": [],
+  "components": {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy": [
+      {
+        "id": "94de99e1-a0f0-4bf8-bcce-a7c3fb779dca",
+        "name": "Consent Required",
+        "providerId": "consent-required",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "ce74f11b-992d-4e27-a7a6-f43152181360",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "saml-user-property-mapper",
+            "saml-user-attribute-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-address-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "oidc-full-name-mapper",
+            "saml-role-list-mapper"
+          ]
+        }
+      },
+      {
+        "id": "9bb4c522-add6-4228-abe9-4feb6dd9f808",
+        "name": "Allowed Protocol Mapper Types",
+        "providerId": "allowed-protocol-mappers",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allowed-protocol-mapper-types": [
+            "oidc-full-name-mapper",
+            "oidc-usermodel-property-mapper",
+            "oidc-address-mapper",
+            "oidc-sha256-pairwise-sub-mapper",
+            "oidc-usermodel-attribute-mapper",
+            "saml-user-property-mapper",
+            "saml-role-list-mapper",
+            "saml-user-attribute-mapper"
+          ]
+        }
+      },
+      {
+        "id": "120aa4be-ec68-4e1e-ab6f-5d30c6104182",
+        "name": "Full Scope Disabled",
+        "providerId": "scope",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {}
+      },
+      {
+        "id": "b4088184-a551-4aeb-8033-b6bb930418c5",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      },
+      {
+        "id": "df42499a-9301-4e45-bf3b-66fe8d46a0be",
+        "name": "Max Clients Limit",
+        "providerId": "max-clients",
+        "subType": "anonymous",
+        "subComponents": {},
+        "config": {
+          "max-clients": [
+            "200"
+          ]
+        }
+      },
+      {
+        "id": "c92385d5-a1fd-489c-82b1-df62a4ecfd22",
+        "name": "Allowed Client Scopes",
+        "providerId": "allowed-client-templates",
+        "subType": "authenticated",
+        "subComponents": {},
+        "config": {
+          "allow-default-scopes": [
+            "true"
+          ]
+        }
+      }
+    ],
+    "org.keycloak.keys.KeyProvider": [
+      {
+        "id": "5160914b-7e83-4990-929b-ec144b61fe7c",
+        "name": "rsa-generated",
+        "providerId": "rsa-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      },
+      {
+        "id": "fd9d79f0-ebf1-49d5-bda0-65f09d7c6217",
+        "name": "rsa-enc-generated",
+        "providerId": "rsa-enc-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "RSA-OAEP"
+          ]
+        }
+      },
+      {
+        "id": "15b71220-6a7c-4553-b3fc-525161ba9c86",
+        "name": "hmac-generated-hs512",
+        "providerId": "hmac-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ],
+          "algorithm": [
+            "HS512"
+          ]
+        }
+      },
+      {
+        "id": "65edd7c7-eb8a-43b1-93de-5ad8d2222bfb",
+        "name": "aes-generated",
+        "providerId": "aes-generated",
+        "subComponents": {},
+        "config": {
+          "priority": [
+            "100"
+          ]
+        }
+      }
+    ]
+  },
+  "internationalizationEnabled": false,
+  "authenticationFlows": [
+    {
+      "id": "cf963669-f073-41ad-aa65-1f6240cd14a8",
+      "alias": "Account verification options",
+      "description": "Method with which to verity the existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-email-verification",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Verify Existing Account by Re-authentication",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "0a78a266-0d7b-4337-b321-f35a4da41988",
+      "alias": "Browser - Conditional 2FA",
+      "description": "Flow to determine if any 2FA is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "webauthn-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-recovery-authn-code-form",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "098fcb3b-be19-4b01-a5f9-db4129939cd9",
+      "alias": "Browser - Conditional Organization",
+      "description": "Flow to determine if the organization identity-first login is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "organization",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "c173e68c-2061-46d2-88fa-38c5ef096786",
+      "alias": "Direct Grant - Conditional OTP",
+      "description": "Flow to determine if the OTP is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "92ed99c5-76eb-4203-ae1a-8fee14b69755",
+      "alias": "First Broker Login - Conditional Organization",
+      "description": "Flow to determine if the authenticator that adds organization members is to be used",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "idp-add-organization-member",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "d5fed9bb-bc3e-4f06-8ed1-5885255dc53d",
+      "alias": "First broker login - Conditional 2FA",
+      "description": "Flow to determine if any 2FA is required for the authentication",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-otp-form",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "webauthn-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-recovery-authn-code-form",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "cefe5381-c0ec-402a-932d-646fe4efe33a",
+      "alias": "Handle Existing Account",
+      "description": "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-confirm-link",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Account verification options",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "8580aa4e-fd43-4be5-a597-35bfdb7fe059",
+      "alias": "Organization",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "ebb86cec-49ac-4714-95a2-52fc3e93e07a",
+      "alias": "Reset - Conditional OTP",
+      "description": "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "conditional-user-configured",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-otp",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "d60df5cb-1e34-496c-95fc-51066da07e59",
+      "alias": "User creation or linking",
+      "description": "Flow for the existing/non-existing user alternatives",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "create unique user config",
+          "authenticator": "idp-create-user-if-unique",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Handle Existing Account",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "5791b389-7824-47a1-a1e2-5bba4ee83a85",
+      "alias": "Verify Existing Account by Re-authentication",
+      "description": "Reauthentication of existing account",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "idp-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "First broker login - Conditional 2FA",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "afbaa431-f2ce-40fd-a2d5-02a76ec5d72b",
+      "alias": "browser",
+      "description": "Browser based authentication",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-cookie",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "auth-spnego",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "identity-provider-redirector",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 25,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 26,
+          "autheticatorFlow": true,
+          "flowAlias": "Organization",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "forms",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "f0ad16d0-50db-4bbf-8215-93f398aaccbb",
+      "alias": "clients",
+      "description": "Base authentication for clients",
+      "providerId": "client-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "client-secret",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-secret-jwt",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "client-x509",
+          "authenticatorFlow": false,
+          "requirement": "ALTERNATIVE",
+          "priority": 40,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "1d8b52db-5307-4440-a51e-8661a3395591",
+      "alias": "direct grant",
+      "description": "OpenID Connect Resource Owner Grant",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "direct-grant-validate-username",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "direct-grant-validate-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 30,
+          "autheticatorFlow": true,
+          "flowAlias": "Direct Grant - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "a8abfd8b-50c8-4aad-abc7-3927a7fb1854",
+      "alias": "docker auth",
+      "description": "Used by Docker clients to authenticate against the IDP",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "docker-http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "f10ee3f9-d0e9-4f75-afd8-0019f30c7534",
+      "alias": "first broker login",
+      "description": "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticatorConfig": "review profile config",
+          "authenticator": "idp-review-profile",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "User creation or linking",
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 50,
+          "autheticatorFlow": true,
+          "flowAlias": "First Broker Login - Conditional Organization",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "82843e3c-1d62-4eb7-87f9-073b667e97d6",
+      "alias": "forms",
+      "description": "Username, password, otp and other auth forms.",
+      "providerId": "basic-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "auth-username-password-form",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 20,
+          "autheticatorFlow": true,
+          "flowAlias": "Browser - Conditional 2FA",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "b89f9838-1cc0-4408-b41f-d0acd73a8084",
+      "alias": "registration",
+      "description": "Registration flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-page-form",
+          "authenticatorFlow": true,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": true,
+          "flowAlias": "registration form",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "dc3b9162-1272-475c-bee9-f2f30c5ad29c",
+      "alias": "registration form",
+      "description": "Registration form",
+      "providerId": "form-flow",
+      "topLevel": false,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "registration-user-creation",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-password-action",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 50,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-recaptcha-action",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 60,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "registration-terms-and-conditions",
+          "authenticatorFlow": false,
+          "requirement": "DISABLED",
+          "priority": 70,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "9971af2a-2c71-49e0-a5cf-d9880e902e50",
+      "alias": "reset credentials",
+      "description": "Reset credentials for a user if they forgot their password or something",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "reset-credentials-choose-user",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-credential-email",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 20,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticator": "reset-password",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 30,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        },
+        {
+          "authenticatorFlow": true,
+          "requirement": "CONDITIONAL",
+          "priority": 40,
+          "autheticatorFlow": true,
+          "flowAlias": "Reset - Conditional OTP",
+          "userSetupAllowed": false
+        }
+      ]
+    },
+    {
+      "id": "cf04531a-40bd-4165-8817-8c16f3c79b55",
+      "alias": "saml ecp",
+      "description": "SAML ECP Profile Authentication Flow",
+      "providerId": "basic-flow",
+      "topLevel": true,
+      "builtIn": true,
+      "authenticationExecutions": [
+        {
+          "authenticator": "http-basic-authenticator",
+          "authenticatorFlow": false,
+          "requirement": "REQUIRED",
+          "priority": 10,
+          "autheticatorFlow": false,
+          "userSetupAllowed": false
+        }
+      ]
+    }
+  ],
+  "authenticatorConfig": [
+    {
+      "id": "316b415d-e7b9-47c3-9c63-52af316700f4",
+      "alias": "create unique user config",
+      "config": {
+        "require.password.update.after.registration": "false"
+      }
+    },
+    {
+      "id": "fdb2513b-859c-40b5-8581-d93121a2bafe",
+      "alias": "review profile config",
+      "config": {
+        "update.profile.on.first.login": "missing"
+      }
+    }
+  ],
+  "requiredActions": [
+    {
+      "alias": "CONFIGURE_TOTP",
+      "name": "Configure OTP",
+      "providerId": "CONFIGURE_TOTP",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 10,
+      "config": {}
+    },
+    {
+      "alias": "TERMS_AND_CONDITIONS",
+      "name": "Terms and Conditions",
+      "providerId": "TERMS_AND_CONDITIONS",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 20,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PASSWORD",
+      "name": "Update Password",
+      "providerId": "UPDATE_PASSWORD",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 30,
+      "config": {}
+    },
+    {
+      "alias": "UPDATE_PROFILE",
+      "name": "Update Profile",
+      "providerId": "UPDATE_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 40,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 50,
+      "config": {}
+    },
+    {
+      "alias": "delete_account",
+      "name": "Delete Account",
+      "providerId": "delete_account",
+      "enabled": false,
+      "defaultAction": false,
+      "priority": 60,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register",
+      "name": "Webauthn Register",
+      "providerId": "webauthn-register",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 70,
+      "config": {}
+    },
+    {
+      "alias": "webauthn-register-passwordless",
+      "name": "Webauthn Register Passwordless",
+      "providerId": "webauthn-register-passwordless",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 80,
+      "config": {}
+    },
+    {
+      "alias": "VERIFY_PROFILE",
+      "name": "Verify Profile",
+      "providerId": "VERIFY_PROFILE",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 90,
+      "config": {}
+    },
+    {
+      "alias": "delete_credential",
+      "name": "Delete Credential",
+      "providerId": "delete_credential",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 100,
+      "config": {}
+    },
+    {
+      "alias": "idp_link",
+      "name": "Linking Identity Provider",
+      "providerId": "idp_link",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 110,
+      "config": {}
+    },
+    {
+      "alias": "CONFIGURE_RECOVERY_AUTHN_CODES",
+      "name": "Recovery Authentication Codes",
+      "providerId": "CONFIGURE_RECOVERY_AUTHN_CODES",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 120,
+      "config": {}
+    },
+    {
+      "alias": "update_user_locale",
+      "name": "Update User Locale",
+      "providerId": "update_user_locale",
+      "enabled": true,
+      "defaultAction": false,
+      "priority": 1000,
+      "config": {}
+    }
+  ],
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "firstBrokerLoginFlow": "first broker login",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DevicePollingInterval": "5",
+    "clientOfflineSessionMaxLifespan": "0",
+    "clientSessionIdleTimeout": "0",
+    "clientOfflineSessionIdleTimeout": "0",
+    "cibaInterval": "5",
+    "realmReusableOtpCode": "false",
+    "cibaExpiresIn": "120",
+    "oauth2DeviceCodeLifespan": "600",
+    "parRequestUriLifespan": "60",
+    "clientSessionMaxLifespan": "0",
+    "darkMode": "true"
+  },
+  "keycloakVersion": "26.3.3",
+  "userManagedAccessAllowed": false,
+  "organizationsEnabled": false,
+  "verifiableCredentialsEnabled": false,
+  "adminPermissionsEnabled": false,
+  "clientProfiles": {
+    "profiles": []
+  },
+  "clientPolicies": {
+    "policies": []
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>resources-tests</module>
         <module>camel-integration-capability-tests</module>
         <module>router-tests</module>
+        <module>mcp-forwarding-tests</module>
     </modules>
 
     <properties>

--- a/resources-tests/src/test/java/ai/wanaku/test/resources/ResourceCliExtendedITCase.java
+++ b/resources-tests/src/test/java/ai/wanaku/test/resources/ResourceCliExtendedITCase.java
@@ -1,0 +1,79 @@
+package ai.wanaku.test.resources;
+
+import java.nio.file.Path;
+import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.client.CLIExecutor;
+import ai.wanaku.test.client.CLIResult;
+import ai.wanaku.test.model.ResourceConfig;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@QuarkusTest
+class ResourceCliExtendedITCase extends ResourceTestBase {
+
+    private CLIExecutor cliExecutor;
+    private String authToken;
+
+    @BeforeEach
+    void checkInfrastructureAvailable() {
+        assertThat(isRouterAvailable()).as("Router must be available").isTrue();
+        assertThat(isFileProviderAvailable())
+                .as("File provider must be available")
+                .isTrue();
+
+        cliExecutor = CLIExecutor.createDefault();
+        assertThat(cliExecutor.isAvailable()).as("CLI must be available").isTrue();
+
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            authToken = keycloakManager.getMcpToken();
+        }
+    }
+
+    @DisplayName("Show details of a registered resource via CLI")
+    @Test
+    void shouldShowResourceViaCli() throws Exception {
+        Path testFile = createTestFile("cli-show-test.txt", "Show test content");
+        ResourceConfig config = ResourceConfig.builder()
+                .name("cli-show-resource")
+                .location(testFile.toUri().toString())
+                .description("Resource for CLI show test")
+                .build();
+
+        routerClient.exposeResource(config);
+
+        CLIResult result = executeWithAuth("resources", "show", "--host", getRouterHost(), "cli-show-resource");
+
+        assertThat(result.isSuccess())
+                .as("CLI show command should succeed: %s", result.getCombinedOutput())
+                .isTrue();
+        assertThat(result.getCombinedOutput()).contains("cli-show-resource");
+    }
+
+    @DisplayName("CLI resources list returns output when no resources exposed")
+    @Test
+    void shouldListEmptyResources() {
+        CLIResult result = executeWithAuth("resources", "list", "--host", getRouterHost());
+
+        assertThat(result.isSuccess())
+                .as("CLI list should succeed even with no resources: %s", result.getCombinedOutput())
+                .isTrue();
+    }
+
+    private String getRouterHost() {
+        return routerManager != null ? routerManager.getBaseUrl() : "http://localhost:8080";
+    }
+
+    private CLIResult executeWithAuth(String... args) {
+        if (authToken != null) {
+            String[] authArgs = new String[args.length + 2];
+            System.arraycopy(args, 0, authArgs, 0, args.length);
+            authArgs[args.length] = "--token";
+            authArgs[args.length + 1] = authToken;
+            return cliExecutor.execute(authArgs);
+        }
+        return cliExecutor.execute(args);
+    }
+}


### PR DESCRIPTION
## Summary

New `mcp-forwarding-tests` module and extensions to existing test modules.

**New mcp-forwarding-tests module (8 tests):**
- `McpForwardingBasicITCase` — forward add/list/remove/refresh using a second Router instance
- `McpForwardingErrorITCase` — unreachable targets, valid targets, clear all

**Extended http-capability-tests (+7 tests):**
- `HttpToolErrorHandlingITCase` — unreachable endpoint, 404, 500, empty response
- `HttpToolCliExtendedITCase` — show, invalid subcommand, empty list

**Extended resources-tests (+2 tests):**
- `ResourceCliExtendedITCase` — show, empty list

**Note:** ~2700 lines are `wanaku-realm.json` (copied from existing modules). Actual code is ~700 lines.

**Depends on:** PR #134 (test-common clients), PR #135 (router-tests)

## Test plan
- [x] `mvn -DskipTests compile` passes
- [x] All tests pass or skip on CI (verified in CI run #8)

## Summary by Sourcery

Add a new MCP forwarding integration test module and extend existing HTTP capability and resource CLI tests to cover additional error handling and CLI scenarios.

Build:
- Register the new mcp-forwarding-tests module in the parent Maven pom and define its Maven configuration and test dependencies.

Tests:
- Introduce mcp-forwarding-tests module with basic and error-path integration tests for MCP-to-MCP forwarding, including setup of a secondary router and HTTP capability target.
- Add HTTP capability tests covering tool error handling for unreachable endpoints, HTTP 4xx/5xx responses, and empty bodies using an httpbin test container.
- Extend HTTP CLI tests to validate tool show, invalid subcommands, and listing behavior, including empty tool lists.
- Extend resource CLI tests to cover showing a registered resource and listing behavior when no resources are exposed.