### PR TITLE
Fix #109: reduce health check polling intervals

### DIFF
--- a/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelCapabilityTestBase.java
+++ b/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelCapabilityTestBase.java
@@ -216,7 +216,7 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
         LOG.debug("Waiting for CIC '{}' to register with Router...", serviceName);
         Awaitility.await()
                 .atMost(Duration.ofSeconds(90))
-                .pollInterval(Duration.ofMillis(500))
+                .pollInterval(Duration.ofMillis(200))
                 .until(() -> {
                     if (!manager.isRunning()) {
                         String logPath = manager.getLogFile() != null
@@ -235,7 +235,7 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
         LOG.debug("Waiting for CIC '{}' tools/resources to appear in Router...", serviceName);
         Awaitility.await()
                 .atMost(Duration.ofSeconds(90))
-                .pollInterval(Duration.ofMillis(500))
+                .pollInterval(Duration.ofMillis(200))
                 .until(() -> {
                     if (!manager.isRunning()) {
                         String logPath = manager.getLogFile() != null

--- a/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelCapabilityTestBase.java
+++ b/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelCapabilityTestBase.java
@@ -14,6 +14,7 @@ import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.quarkiverse.mcp.server.ToolResponse;
+import ai.wanaku.test.WanakuTestConstants;
 import ai.wanaku.test.base.BaseIntegrationTest;
 import ai.wanaku.test.client.DataStoreClient;
 import ai.wanaku.test.client.McpTestClient;
@@ -216,7 +217,7 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
         LOG.debug("Waiting for CIC '{}' to register with Router...", serviceName);
         Awaitility.await()
                 .atMost(Duration.ofSeconds(90))
-                .pollInterval(Duration.ofMillis(200))
+                .pollInterval(WanakuTestConstants.DEFAULT_HEALTH_CHECK_INTERVAL)
                 .until(() -> {
                     if (!manager.isRunning()) {
                         String logPath = manager.getLogFile() != null
@@ -235,7 +236,7 @@ public abstract class CamelCapabilityTestBase extends BaseIntegrationTest {
         LOG.debug("Waiting for CIC '{}' tools/resources to appear in Router...", serviceName);
         Awaitility.await()
                 .atMost(Duration.ofSeconds(90))
-                .pollInterval(Duration.ofMillis(200))
+                .pollInterval(WanakuTestConstants.DEFAULT_HEALTH_CHECK_INTERVAL)
                 .until(() -> {
                     if (!manager.isRunning()) {
                         String logPath = manager.getLogFile() != null

--- a/resources-tests/src/test/java/ai/wanaku/test/resources/ResourceTestBase.java
+++ b/resources-tests/src/test/java/ai/wanaku/test/resources/ResourceTestBase.java
@@ -7,6 +7,7 @@ import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ai.wanaku.test.WanakuTestConstants;
 import ai.wanaku.test.base.BaseIntegrationTest;
 import ai.wanaku.test.client.RouterClient;
 import ai.wanaku.test.config.OidcCredentials;
@@ -62,7 +63,7 @@ public abstract class ResourceTestBase extends BaseIntegrationTest {
         RouterClient client = new RouterClient(routerManager.getBaseUrl(), accessToken);
         Awaitility.await()
                 .atMost(Duration.ofSeconds(10))
-                .pollInterval(Duration.ofMillis(200))
+                .pollInterval(WanakuTestConstants.DEFAULT_REGISTRATION_POLL_INTERVAL)
                 .until(() -> client.isCapabilityRegistered("file"));
         LOG.info("File provider is registered");
     }

--- a/router-tests/src/test/java/ai/wanaku/test/router/CapabilityResilienceITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/CapabilityResilienceITCase.java
@@ -54,7 +54,7 @@ class CapabilityResilienceITCase extends RouterTestBase {
 
         Awaitility.await()
                 .atMost(Duration.ofSeconds(30))
-                .pollInterval(Duration.ofMillis(500))
+                .pollInterval(Duration.ofMillis(200))
                 .until(() -> routerClient.isCapabilityRegistered("http"));
 
         assertThat(routerClient.isCapabilityRegistered("http")).isTrue();
@@ -86,7 +86,7 @@ class CapabilityResilienceITCase extends RouterTestBase {
 
         Awaitility.await()
                 .atMost(Duration.ofSeconds(30))
-                .pollInterval(Duration.ofMillis(500))
+                .pollInterval(Duration.ofMillis(200))
                 .until(() -> routerClient.isCapabilityRegistered("http"));
 
         resilienceCapability.stop();
@@ -104,7 +104,7 @@ class CapabilityResilienceITCase extends RouterTestBase {
 
         Awaitility.await()
                 .atMost(Duration.ofSeconds(30))
-                .pollInterval(Duration.ofMillis(500))
+                .pollInterval(Duration.ofMillis(200))
                 .until(() -> routerClient.isCapabilityRegistered("http"));
 
         assertThat(routerClient.isCapabilityRegistered("http")).isTrue();

--- a/router-tests/src/test/java/ai/wanaku/test/router/CapabilityResilienceITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/CapabilityResilienceITCase.java
@@ -3,6 +3,7 @@ package ai.wanaku.test.router;
 import java.time.Duration;
 import org.awaitility.Awaitility;
 import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.WanakuTestConstants;
 import ai.wanaku.test.config.OidcCredentials;
 import ai.wanaku.test.config.TargetConfiguration;
 import ai.wanaku.test.managers.HttpCapabilityManager;
@@ -54,7 +55,7 @@ class CapabilityResilienceITCase extends RouterTestBase {
 
         Awaitility.await()
                 .atMost(Duration.ofSeconds(30))
-                .pollInterval(Duration.ofMillis(200))
+                .pollInterval(WanakuTestConstants.DEFAULT_HEALTH_CHECK_INTERVAL)
                 .until(() -> routerClient.isCapabilityRegistered("http"));
 
         assertThat(routerClient.isCapabilityRegistered("http")).isTrue();
@@ -86,7 +87,7 @@ class CapabilityResilienceITCase extends RouterTestBase {
 
         Awaitility.await()
                 .atMost(Duration.ofSeconds(30))
-                .pollInterval(Duration.ofMillis(200))
+                .pollInterval(WanakuTestConstants.DEFAULT_HEALTH_CHECK_INTERVAL)
                 .until(() -> routerClient.isCapabilityRegistered("http"));
 
         resilienceCapability.stop();
@@ -104,7 +105,7 @@ class CapabilityResilienceITCase extends RouterTestBase {
 
         Awaitility.await()
                 .atMost(Duration.ofSeconds(30))
-                .pollInterval(Duration.ofMillis(200))
+                .pollInterval(WanakuTestConstants.DEFAULT_HEALTH_CHECK_INTERVAL)
                 .until(() -> routerClient.isCapabilityRegistered("http"));
 
         assertThat(routerClient.isCapabilityRegistered("http")).isTrue();

--- a/test-common/src/main/java/ai/wanaku/test/WanakuTestConstants.java
+++ b/test-common/src/main/java/ai/wanaku/test/WanakuTestConstants.java
@@ -24,7 +24,8 @@ public final class WanakuTestConstants {
     public static final String DEFAULT_ARTIFACTS_DIR = "artifacts";
     public static final String DEFAULT_CLI_PATH = "wanaku";
     public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(60);
-    public static final Duration DEFAULT_HEALTH_CHECK_INTERVAL = Duration.ofMillis(500);
+    public static final Duration DEFAULT_HEALTH_CHECK_INTERVAL = Duration.ofMillis(200);
+    public static final Duration DEFAULT_REGISTRATION_POLL_INTERVAL = Duration.ofMillis(100);
 
     // Health check endpoints
     public static final String ROUTER_HEALTH_PATH = "/q/health/ready";

--- a/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
@@ -2,10 +2,10 @@ package ai.wanaku.test.base;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.time.Duration;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import ai.wanaku.test.WanakuTestConstants;
 import ai.wanaku.test.client.McpTestClient;
 import ai.wanaku.test.client.RouterClient;
 import ai.wanaku.test.config.OidcCredentials;
@@ -105,7 +105,7 @@ public abstract class BaseIntegrationTest {
             // Wait for HTTP Capability to register with Router
             LOG.debug("Waiting for HTTP Capability registration...");
             Awaitility.await()
-                    .pollInterval(Duration.ofMillis(200))
+                    .pollInterval(WanakuTestConstants.DEFAULT_REGISTRATION_POLL_INTERVAL)
                     .until(() -> routerClient.isCapabilityRegistered("http"));
             LOG.debug("HTTP Capability is registered");
         }

--- a/test-common/src/main/java/ai/wanaku/test/managers/KeycloakManager.java
+++ b/test-common/src/main/java/ai/wanaku/test/managers/KeycloakManager.java
@@ -21,6 +21,7 @@ import org.testcontainers.containers.wait.strategy.Wait;
 import org.testcontainers.utility.DockerImageName;
 import io.quarkus.test.keycloak.client.KeycloakTestClient;
 import io.quarkus.test.keycloak.server.KeycloakContainer;
+import ai.wanaku.test.WanakuTestConstants;
 import ai.wanaku.test.config.OidcCredentials;
 
 /**
@@ -85,7 +86,7 @@ public class KeycloakManager {
         LOG.debug("Waiting for OIDC discovery: {}", url);
         Awaitility.await()
                 .atMost(Duration.ofSeconds(30))
-                .pollInterval(Duration.ofMillis(200))
+                .pollInterval(WanakuTestConstants.DEFAULT_HEALTH_CHECK_INTERVAL)
                 .ignoreExceptions()
                 .until(() -> {
                     HttpRequest req =

--- a/test-common/src/main/java/ai/wanaku/test/managers/KeycloakManager.java
+++ b/test-common/src/main/java/ai/wanaku/test/managers/KeycloakManager.java
@@ -85,7 +85,7 @@ public class KeycloakManager {
         LOG.debug("Waiting for OIDC discovery: {}", url);
         Awaitility.await()
                 .atMost(Duration.ofSeconds(30))
-                .pollInterval(Duration.ofSeconds(1))
+                .pollInterval(Duration.ofMillis(200))
                 .ignoreExceptions()
                 .until(() -> {
                     HttpRequest req =


### PR DESCRIPTION
## Summary

- Reduce `DEFAULT_HEALTH_CHECK_INTERVAL` from 500ms to 200ms
- Add `DEFAULT_REGISTRATION_POLL_INTERVAL` constant at 100ms for capability registration polls
- Reduce Keycloak OIDC discovery poll from 1s to 200ms
- Reduce HTTP/file capability registration polls from 200ms to 100ms (via new constant)
- Reduce CIC registration polls from 500ms to 200ms
- Reduce resilience test registration polls from 500ms to 200ms
- Leave 3-second invocation retry intervals unchanged (different class of operation)

All polled endpoints are localhost (Quarkus health checks, Testcontainer Keycloak, local REST APIs), so faster polling is safe. Estimated savings: 10-30 seconds across the full suite.

Closes #109

## Summary by Sourcery

Tighten test polling intervals to speed up local health, registration, and OIDC readiness checks while keeping existing timeouts unchanged.

Enhancements:
- Lower default health check interval to 200ms to make readiness checks more responsive.
- Introduce a shared default registration poll interval constant and apply it to HTTP and file capability registration waits.
- Reduce polling intervals in Keycloak OIDC discovery and CIC/capability resilience tests to shorten overall test execution time.