### PR TITLE
fix: update missing required parameter test to expect validation error

### DIFF
--- a/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelBasicToolITCase.java
+++ b/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelBasicToolITCase.java
@@ -90,7 +90,7 @@ class CamelBasicToolITCase extends CamelCapabilityTestBase {
         });
     }
 
-    @DisplayName("Invoke weather-lookup without required city parameter")
+    @DisplayName("Invoke weather-lookup without required city parameter returns validation error")
     @Test
     void shouldHandleMissingRequiredParameter() throws Exception {
         startCapability("simple-tool-svc", "simple-tool");
@@ -101,11 +101,11 @@ class CamelBasicToolITCase extends CamelCapabilityTestBase {
                     response.isError(),
                     response.content());
             assertThat(response.isError())
-                    .as("CIC does not validate required params")
-                    .isFalse();
+                    .as("CIC should reject calls with missing required params")
+                    .isTrue();
             String text = response.content().get(0).asText().text();
-            assertThat(text).contains("Weather report for");
-            assertThat(text).doesNotContain("London");
+            assertThat(text).containsIgnoringCase("missing required parameter");
+            assertThat(text).contains("city");
         });
     }
 


### PR DESCRIPTION
## Summary

- Updates `CamelBasicToolITCase.shouldHandleMissingRequiredParameter` to expect `isError=true` with a validation message about the missing `city` parameter
- Previously expected a successful response (which never arrived, causing a 90s timeout)

## Details

The CIC SDK now validates required parameters before invoking Camel routes (see wanaku-ai/wanaku-capabilities-java-sdk#188). This test needs to match the new behavior: calling `weather-lookup` without the required `city` parameter should return a tool error, not a successful response.

## Test plan

- [ ] Run `CamelBasicToolITCase` with updated SDK to verify the test passes

Ref: orpiske/camel-integration-capability#127

## Summary by Sourcery

Tests:
- Update CamelBasicToolITCase to expect a validation error and message when invoking weather-lookup without the required city parameter.