### PR TITLE
Fix #144: add namespace argument to CLI tools add and resources expose tests

### DIFF
--- a/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolCliITCase.java
+++ b/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolCliITCase.java
@@ -1,13 +1,19 @@
 package ai.wanaku.test.http;
 
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import io.quarkus.test.junit.QuarkusTest;
 import ai.wanaku.test.client.CLIExecutor;
 import ai.wanaku.test.client.CLIResult;
+import ai.wanaku.test.client.NamespaceClient;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Tests for HTTP tool registration via CLI.
@@ -16,6 +22,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @QuarkusTest
 class HttpToolCliITCase extends HttpCapabilityTestBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(HttpToolCliITCase.class);
+    private static final String NAMESPACE_NAME = "tools-cli-test-ns";
 
     private CLIExecutor cliExecutor;
     private String authToken;
@@ -29,6 +38,9 @@ class HttpToolCliITCase extends HttpCapabilityTestBase {
         if (keycloakManager != null && keycloakManager.isRunning()) {
             authToken = keycloakManager.getMcpToken();
         }
+
+        String nsId = getOrCreateNamespaceId(NAMESPACE_NAME);
+        assumeThat(nsId).as("Test namespace must be available").isNotNull();
     }
 
     @DisplayName("Register a tool via CLI and verify it appears in CLI list output")
@@ -44,6 +56,8 @@ class HttpToolCliITCase extends HttpCapabilityTestBase {
                 "add",
                 "--host",
                 getRouterHost(),
+                "-N",
+                NAMESPACE_NAME,
                 "--name",
                 toolName,
                 "--type",
@@ -123,6 +137,22 @@ class HttpToolCliITCase extends HttpCapabilityTestBase {
         assertThat(listResult.getCombinedOutput())
                 .as("CLI list output should not contain the removed tool")
                 .doesNotContain(toolName);
+    }
+
+    private String getOrCreateNamespaceId(String name) {
+        NamespaceClient nsClient = new NamespaceClient(routerManager.getBaseUrl(), authToken);
+        try {
+            List<JsonNode> namespaces = nsClient.list();
+            for (JsonNode ns : namespaces) {
+                if (ns.has("name") && name.equals(ns.get("name").asText())) {
+                    return ns.has("id") ? ns.get("id").asText() : null;
+                }
+            }
+            return nsClient.create(name, "/" + name);
+        } catch (Exception e) {
+            LOG.warn("Failed to get/create namespace '{}': {}", name, e.getMessage());
+            return null;
+        }
     }
 
     private String getRouterHost() {

--- a/resources-tests/src/test/java/ai/wanaku/test/resources/CliResourceITCase.java
+++ b/resources-tests/src/test/java/ai/wanaku/test/resources/CliResourceITCase.java
@@ -1,15 +1,21 @@
 package ai.wanaku.test.resources;
 
 import java.nio.file.Path;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import io.quarkus.test.junit.QuarkusTest;
 import ai.wanaku.test.client.CLIExecutor;
 import ai.wanaku.test.client.CLIResult;
+import ai.wanaku.test.client.NamespaceClient;
 import ai.wanaku.test.model.ResourceConfig;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Tests for resource operations via CLI.
@@ -17,6 +23,9 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @QuarkusTest
 class CliResourceITCase extends ResourceTestBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CliResourceITCase.class);
+    private static final String NAMESPACE_NAME = "resources-cli-test-ns";
 
     private CLIExecutor cliExecutor;
     private String authToken;
@@ -33,6 +42,25 @@ class CliResourceITCase extends ResourceTestBase {
 
         if (keycloakManager != null && keycloakManager.isRunning()) {
             authToken = keycloakManager.getMcpToken();
+        }
+
+        String nsId = getOrCreateNamespaceId(NAMESPACE_NAME);
+        assumeThat(nsId).as("Test namespace must be available").isNotNull();
+    }
+
+    private String getOrCreateNamespaceId(String name) {
+        NamespaceClient nsClient = new NamespaceClient(routerManager.getBaseUrl(), authToken);
+        try {
+            List<JsonNode> namespaces = nsClient.list();
+            for (JsonNode ns : namespaces) {
+                if (ns.has("name") && name.equals(ns.get("name").asText())) {
+                    return ns.has("id") ? ns.get("id").asText() : null;
+                }
+            }
+            return nsClient.create(name, "/" + name);
+        } catch (Exception e) {
+            LOG.warn("Failed to get/create namespace '{}': {}", name, e.getMessage());
+            return null;
         }
     }
 
@@ -59,6 +87,8 @@ class CliResourceITCase extends ResourceTestBase {
                 "expose",
                 "--host",
                 routerHost,
+                "-N",
+                NAMESPACE_NAME,
                 "--name",
                 "test-cli-resource",
                 "--description",


### PR DESCRIPTION
## Summary
- Add `-N <namespace>` argument to `tools add` CLI command in `HttpToolCliITCase`
- Add `-N <namespace>` argument to `resources expose` CLI command in `CliResourceITCase`
- Create test namespace via `NamespaceClient` in `@BeforeEach` (following `RouterTestBase` pattern)
- Use `assumeThat` to gracefully skip if namespace creation fails, with WARN-level logging

## Test plan
- [ ] Verify `HttpToolCliITCase.shouldRegisterHttpToolViaCli` passes with namespace arg
- [ ] Verify `CliResourceITCase.shouldExposeResourceViaCli` passes with namespace arg
- [ ] Verify existing list/remove tests still pass (unchanged)
- [ ] Run full integration test workflow against 0.2.x and main

## Summary by Sourcery

Add namespace-aware setup to CLI integration tests for tools and resources to ensure commands target a dedicated test namespace.

New Features:
- Support passing a namespace argument to the `tools add` CLI integration test to register HTTP tools within a specific namespace.
- Support passing a namespace argument to the `resources expose` CLI integration test to expose resources within a specific namespace.

Enhancements:
- Introduce shared namespace creation and lookup via `NamespaceClient` in CLI integration tests, with graceful skipping when namespaces cannot be created and warn-level logging.