### PR TITLE
fix: remove leading slash from namespace path in test namespace creation

### DIFF
--- a/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolCliITCase.java
+++ b/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolCliITCase.java
@@ -148,7 +148,7 @@ class HttpToolCliITCase extends HttpCapabilityTestBase {
                     return ns.has("id") ? ns.get("id").asText() : null;
                 }
             }
-            return nsClient.create(name, "/" + name);
+            return nsClient.create(name, name);
         } catch (Exception e) {
             LOG.warn("Failed to get/create namespace '{}': {}", name, e.getMessage());
             return null;

--- a/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingTestBase.java
+++ b/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingTestBase.java
@@ -91,7 +91,7 @@ public abstract class McpForwardingTestBase extends BaseIntegrationTest {
                     }
                 }
                 if (testNamespaceId == null) {
-                    testNamespaceId = namespaceClient.create("fwd-test-ns", "/fwd-test-ns");
+                    testNamespaceId = namespaceClient.create("fwd-test-ns", "fwd-test-ns");
                 }
             } catch (Exception e) {
                 LOG.warn("Failed to setup test namespace: {}", e.getMessage());

--- a/resources-tests/src/test/java/ai/wanaku/test/resources/CliResourceITCase.java
+++ b/resources-tests/src/test/java/ai/wanaku/test/resources/CliResourceITCase.java
@@ -57,7 +57,7 @@ class CliResourceITCase extends ResourceTestBase {
                     return ns.has("id") ? ns.get("id").asText() : null;
                 }
             }
-            return nsClient.create(name, "/" + name);
+            return nsClient.create(name, name);
         } catch (Exception e) {
             LOG.warn("Failed to get/create namespace '{}': {}", name, e.getMessage());
             return null;

--- a/router-tests/src/test/java/ai/wanaku/test/router/NamespaceCliITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/NamespaceCliITCase.java
@@ -33,7 +33,7 @@ class NamespaceCliITCase extends RouterTestBase {
         String name = "test-cli-ns";
 
         CLIResult result = executeWithAuth(
-                "namespaces", "create", "--host", getRouterHost(), "--name", name, "--path", "/" + name);
+                "namespaces", "create", "--host", getRouterHost(), "--name", name, "--path", name);
 
         assertThat(result.isSuccess())
                 .as("CLI command should succeed: %s", result.getCombinedOutput())
@@ -45,7 +45,7 @@ class NamespaceCliITCase extends RouterTestBase {
     @Test
     void shouldListNamespacesViaCli() {
         String name = "cli-list-ns";
-        namespaceClient.create(name, "/" + name);
+        namespaceClient.create(name, name);
 
         CLIResult result = executeWithAuth("namespaces", "list", "--host", getRouterHost());
 
@@ -62,7 +62,7 @@ class NamespaceCliITCase extends RouterTestBase {
     @Test
     void shouldDeleteNamespaceViaCli() {
         String name = "cli-delete-ns";
-        String id = namespaceClient.create(name, "/" + name);
+        String id = namespaceClient.create(name, name);
         assertThat(namespaceClient.exists(name)).isTrue();
 
         CLIResult result = executeWithAuth("namespaces", "delete", "--host", getRouterHost(), "--name", id);

--- a/router-tests/src/test/java/ai/wanaku/test/router/NamespaceCrudITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/NamespaceCrudITCase.java
@@ -21,7 +21,7 @@ class NamespaceCrudITCase extends RouterTestBase {
     @DisplayName("Create a namespace and verify it exists")
     @Test
     void shouldCreateNamespace() {
-        String id = namespaceClient.create("test-ns", "/test-ns");
+        String id = namespaceClient.create("test-ns", "test-ns");
 
         assertThat(id).isNotNull();
         assertThat(namespaceClient.exists("test-ns")).isTrue();
@@ -38,7 +38,7 @@ class NamespaceCrudITCase extends RouterTestBase {
     @DisplayName("Create a namespace, show it by ID, and verify returned node has the name")
     @Test
     void shouldShowNamespace() {
-        String id = namespaceClient.create("show-ns", "/show-ns");
+        String id = namespaceClient.create("show-ns", "show-ns");
         assumeThat(id).as("Namespace ID must be returned").isNotNull();
 
         JsonNode node = namespaceClient.show(id);
@@ -51,7 +51,7 @@ class NamespaceCrudITCase extends RouterTestBase {
     @DisplayName("Create a namespace, delete it by ID, and verify it no longer exists")
     @Test
     void shouldDeleteNamespace() {
-        String id = namespaceClient.create("delete-ns", "/delete-ns");
+        String id = namespaceClient.create("delete-ns", "delete-ns");
         assumeThat(id).as("Namespace ID must be returned").isNotNull();
         assertThat(namespaceClient.exists("delete-ns")).isTrue();
 

--- a/router-tests/src/test/java/ai/wanaku/test/router/RouterTestBase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/RouterTestBase.java
@@ -81,7 +81,7 @@ public abstract class RouterTestBase extends BaseIntegrationTest {
                     return ns.has("id") ? ns.get("id").asText() : null;
                 }
             }
-            return namespaceClient.create(name, "/" + name);
+            return namespaceClient.create(name, name);
         } catch (Exception e) {
             LOG.warn("Failed to get/create namespace '{}': {}", name, e.getMessage());
             return null;


### PR DESCRIPTION
## Summary

- Remove leading `/` prefix from namespace `path` argument across all test modules
- The path was being created as `"/tools-cli-test-ns"` instead of `"tools-cli-test-ns"`, causing `IllegalStateException: Invalid server name` when the router used the namespace path as a gRPC server name during tool/resource registration

## Affected files (6)

- `HttpToolCliITCase.java` — http-capability-tests
- `CliResourceITCase.java` — resources-tests
- `NamespaceCliITCase.java` — router-tests
- `NamespaceCrudITCase.java` — router-tests
- `RouterTestBase.java` — router-tests
- `McpForwardingTestBase.java` — mcp-forwarding-tests

## Test plan

- [ ] Verify `shouldRegisterHttpToolViaCli` passes (was failing with "Invalid server name")
- [ ] Verify `shouldExposeResourceViaCli` passes (was failing with "Invalid server name")
- [ ] Verify namespace CRUD tests still pass
- [ ] Verify MCP forwarding tests are no longer silently skipped due to namespace creation failure

## Summary by Sourcery

Bug Fixes:
- Remove leading slash from namespace path arguments in test namespace creation to avoid invalid gRPC server name failures and silently skipped forwarding tests.