### PR TITLE
fix: use pre-allocated namespace slots instead of creating custom paths

### DIFF
--- a/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolCliITCase.java
+++ b/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolCliITCase.java
@@ -1,13 +1,11 @@
 package ai.wanaku.test.http;
 
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.quarkus.test.junit.QuarkusTest;
 import ai.wanaku.test.client.CLIExecutor;
 import ai.wanaku.test.client.CLIResult;
 import ai.wanaku.test.client.NamespaceClient;
-import com.fasterxml.jackson.databind.JsonNode;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -140,15 +138,9 @@ class HttpToolCliITCase extends HttpCapabilityTestBase {
     }
 
     private String getOrCreateNamespaceId(String name) {
-        NamespaceClient nsClient = new NamespaceClient(routerManager.getBaseUrl(), authToken);
         try {
-            List<JsonNode> namespaces = nsClient.list();
-            for (JsonNode ns : namespaces) {
-                if (ns.has("name") && name.equals(ns.get("name").asText())) {
-                    return ns.has("id") ? ns.get("id").asText() : null;
-                }
-            }
-            return nsClient.create(name, name);
+            NamespaceClient nsClient = new NamespaceClient(routerManager.getBaseUrl(), authToken);
+            return findOrAllocateNamespace(nsClient, name);
         } catch (Exception e) {
             LOG.warn("Failed to get/create namespace '{}': {}", name, e.getMessage());
             return null;

--- a/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingTestBase.java
+++ b/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingTestBase.java
@@ -1,7 +1,6 @@
 package ai.wanaku.test.forward;
 
 import java.io.IOException;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ai.wanaku.test.base.BaseIntegrationTest;
@@ -83,16 +82,7 @@ public abstract class McpForwardingTestBase extends BaseIntegrationTest {
             forwardsClient = new ForwardsClient(routerManager.getBaseUrl(), accessToken);
             namespaceClient = new NamespaceClient(routerManager.getBaseUrl(), accessToken);
             try {
-                List<JsonNode> namespaces = namespaceClient.list();
-                for (JsonNode ns : namespaces) {
-                    if (ns.has("name") && "fwd-test-ns".equals(ns.get("name").asText())) {
-                        testNamespaceId = ns.get("id").asText();
-                        break;
-                    }
-                }
-                if (testNamespaceId == null) {
-                    testNamespaceId = namespaceClient.create("fwd-test-ns", "fwd-test-ns");
-                }
+                testNamespaceId = findOrAllocateNamespace(namespaceClient, "fwd-test-ns");
             } catch (Exception e) {
                 LOG.warn("Failed to setup test namespace: {}", e.getMessage());
             }

--- a/resources-tests/src/test/java/ai/wanaku/test/resources/CliResourceITCase.java
+++ b/resources-tests/src/test/java/ai/wanaku/test/resources/CliResourceITCase.java
@@ -1,7 +1,6 @@
 package ai.wanaku.test.resources;
 
 import java.nio.file.Path;
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import io.quarkus.test.junit.QuarkusTest;
@@ -9,7 +8,6 @@ import ai.wanaku.test.client.CLIExecutor;
 import ai.wanaku.test.client.CLIResult;
 import ai.wanaku.test.client.NamespaceClient;
 import ai.wanaku.test.model.ResourceConfig;
-import com.fasterxml.jackson.databind.JsonNode;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -49,15 +47,9 @@ class CliResourceITCase extends ResourceTestBase {
     }
 
     private String getOrCreateNamespaceId(String name) {
-        NamespaceClient nsClient = new NamespaceClient(routerManager.getBaseUrl(), authToken);
         try {
-            List<JsonNode> namespaces = nsClient.list();
-            for (JsonNode ns : namespaces) {
-                if (ns.has("name") && name.equals(ns.get("name").asText())) {
-                    return ns.has("id") ? ns.get("id").asText() : null;
-                }
-            }
-            return nsClient.create(name, name);
+            NamespaceClient nsClient = new NamespaceClient(routerManager.getBaseUrl(), authToken);
+            return findOrAllocateNamespace(nsClient, name);
         } catch (Exception e) {
             LOG.warn("Failed to get/create namespace '{}': {}", name, e.getMessage());
             return null;

--- a/router-tests/src/test/java/ai/wanaku/test/router/RouterTestBase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/RouterTestBase.java
@@ -1,6 +1,5 @@
 package ai.wanaku.test.router;
 
-import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ai.wanaku.test.base.BaseIntegrationTest;
@@ -10,7 +9,6 @@ import ai.wanaku.test.client.ManagementClient;
 import ai.wanaku.test.client.NamespaceClient;
 import ai.wanaku.test.client.PromptsClient;
 import ai.wanaku.test.client.ServiceCatalogClient;
-import com.fasterxml.jackson.databind.JsonNode;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -75,13 +73,7 @@ public abstract class RouterTestBase extends BaseIntegrationTest {
             return null;
         }
         try {
-            List<JsonNode> namespaces = namespaceClient.list();
-            for (JsonNode ns : namespaces) {
-                if (ns.has("name") && name.equals(ns.get("name").asText())) {
-                    return ns.has("id") ? ns.get("id").asText() : null;
-                }
-            }
-            return namespaceClient.create(name, name);
+            return findOrAllocateNamespace(namespaceClient, name);
         } catch (Exception e) {
             LOG.warn("Failed to get/create namespace '{}': {}", name, e.getMessage());
             return null;

--- a/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
@@ -2,12 +2,16 @@ package ai.wanaku.test.base;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ai.wanaku.test.WanakuTestConstants;
 import ai.wanaku.test.client.McpTestClient;
+import ai.wanaku.test.client.NamespaceClient;
 import ai.wanaku.test.client.RouterClient;
+import com.fasterxml.jackson.databind.JsonNode;
 import ai.wanaku.test.config.OidcCredentials;
 import ai.wanaku.test.config.TargetConfiguration;
 import ai.wanaku.test.config.TestConfiguration;
@@ -188,6 +192,32 @@ public abstract class BaseIntegrationTest {
         }
         // Check preconditions (for @EnabledIf which runs before @BeforeEach)
         return isRouterAvailable();
+    }
+
+    /**
+     * Finds or allocates a pre-allocated namespace for the given name.
+     * The router pre-allocates namespace slots at startup, each backed by an MCP server instance.
+     * This method first looks for an existing namespace with the given name. If not found,
+     * it assigns the name to an unallocated slot via update.
+     *
+     * @return the namespace ID, or null if no slot is available
+     */
+    protected static String findOrAllocateNamespace(NamespaceClient nsClient, String name) {
+        List<JsonNode> namespaces = nsClient.list();
+        for (JsonNode ns : namespaces) {
+            if (ns.has("name") && name.equals(ns.get("name").asText())) {
+                return ns.has("id") ? ns.get("id").asText() : null;
+            }
+        }
+        for (JsonNode ns : namespaces) {
+            if ((!ns.has("name") || ns.get("name").isNull()) && ns.has("id")) {
+                String id = ns.get("id").asText();
+                nsClient.update(id, Map.of("name", name));
+                return id;
+            }
+        }
+        LOG.warn("No pre-allocated namespace available for '{}'", name);
+        return null;
     }
 
     /**


### PR DESCRIPTION
## Summary

- Changed `getOrCreateNamespaceId` in 4 files to allocate pre-allocated namespace slots instead of creating namespaces with custom paths
- The router pre-allocates namespace slots (`ns-0` through `ns-N`) at startup, each with a corresponding MCP server instance. When a tool is registered under a namespace, `ToolsHelper.setServerName(namespace.getPath())` uses the namespace path as the MCP server name — so it must match a pre-allocated slot
- Previously, `nsClient.create(name, name)` created a namespace with a custom path (e.g., `tools-cli-test-ns`) that didn't match any MCP server, causing `IllegalStateException: Invalid server name`
- Now the tests find an unallocated slot (one with `name: null`) and assign the test name to it via `update()`

## Affected files (4)

- `HttpToolCliITCase.java` — http-capability-tests
- `CliResourceITCase.java` — resources-tests
- `RouterTestBase.java` — router-tests
- `McpForwardingTestBase.java` — mcp-forwarding-tests

## Test plan

- [ ] Verify `shouldRegisterHttpToolViaCli` passes (was failing with "Invalid server name: tools-cli-test-ns")
- [ ] Verify `shouldExposeResourceViaCli` passes (was failing with same error)
- [ ] Verify `shouldAddForwardViaCli` still passes
- [ ] Verify MCP forwarding tests are not skipped due to namespace setup failure

## Summary by Sourcery

Align test namespace creation with pre-allocated router namespace slots to avoid invalid MCP server names and namespace setup failures.

Bug Fixes:
- Ensure CLI-based HTTP tool registration uses an existing pre-allocated namespace slot instead of creating a custom-path namespace.
- Ensure CLI-based resource exposure uses an existing pre-allocated namespace slot instead of creating a custom-path namespace.
- Ensure router tests bind test namespaces to pre-allocated slots, preventing invalid server name errors.
- Ensure MCP forwarding tests use pre-allocated namespace slots so forwarding namespaces are created reliably without being skipped.

Enhancements:
- Log a warning when no pre-allocated namespace slot is available for a requested test namespace.