### PR TITLE
fix: remove namespace pre-creation from CLI tests, use on-demand allocation

### DIFF
--- a/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolCliITCase.java
+++ b/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolCliITCase.java
@@ -37,8 +37,10 @@ class HttpToolCliITCase extends HttpCapabilityTestBase {
             authToken = keycloakManager.getMcpToken();
         }
 
-        String nsId = getOrCreateNamespaceId(NAMESPACE_NAME);
-        assumeThat(nsId).as("Test namespace must be available").isNotNull();
+        NamespaceClient nsClient = new NamespaceClient(routerManager.getBaseUrl(), authToken);
+        assumeThat(hasAvailableNamespaces(nsClient))
+                .as("Router must have available namespace slots")
+                .isTrue();
     }
 
     @DisplayName("Register a tool via CLI and verify it appears in CLI list output")
@@ -135,16 +137,6 @@ class HttpToolCliITCase extends HttpCapabilityTestBase {
         assertThat(listResult.getCombinedOutput())
                 .as("CLI list output should not contain the removed tool")
                 .doesNotContain(toolName);
-    }
-
-    private String getOrCreateNamespaceId(String name) {
-        try {
-            NamespaceClient nsClient = new NamespaceClient(routerManager.getBaseUrl(), authToken);
-            return findOrAllocateNamespace(nsClient, name);
-        } catch (Exception e) {
-            LOG.warn("Failed to get/create namespace '{}': {}", name, e.getMessage());
-            return null;
-        }
     }
 
     private String getRouterHost() {

--- a/resources-tests/src/test/java/ai/wanaku/test/resources/CliResourceITCase.java
+++ b/resources-tests/src/test/java/ai/wanaku/test/resources/CliResourceITCase.java
@@ -42,18 +42,10 @@ class CliResourceITCase extends ResourceTestBase {
             authToken = keycloakManager.getMcpToken();
         }
 
-        String nsId = getOrCreateNamespaceId(NAMESPACE_NAME);
-        assumeThat(nsId).as("Test namespace must be available").isNotNull();
-    }
-
-    private String getOrCreateNamespaceId(String name) {
-        try {
-            NamespaceClient nsClient = new NamespaceClient(routerManager.getBaseUrl(), authToken);
-            return findOrAllocateNamespace(nsClient, name);
-        } catch (Exception e) {
-            LOG.warn("Failed to get/create namespace '{}': {}", name, e.getMessage());
-            return null;
-        }
+        NamespaceClient nsClient = new NamespaceClient(routerManager.getBaseUrl(), authToken);
+        assumeThat(hasAvailableNamespaces(nsClient))
+                .as("Router must have available namespace slots")
+                .isTrue();
     }
 
     private CLIResult executeWithAuth(String... args) {

--- a/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
@@ -3,7 +3,6 @@ package ai.wanaku.test.base;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
-import java.util.Map;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -195,29 +194,19 @@ public abstract class BaseIntegrationTest {
     }
 
     /**
-     * Finds or allocates a pre-allocated namespace for the given name.
-     * The router pre-allocates namespace slots at startup, each backed by an MCP server instance.
-     * This method first looks for an existing namespace with the given name. If not found,
-     * it assigns the name to an unallocated slot via update.
-     *
-     * @return the namespace ID, or null if no slot is available
+     * Checks whether the router has pre-allocated namespace slots available.
+     * Tests that register tools/resources under a namespace should call this
+     * to skip gracefully when no slots are available.
      */
-    protected static String findOrAllocateNamespace(NamespaceClient nsClient, String name) {
-        List<JsonNode> namespaces = nsClient.list();
-        for (JsonNode ns : namespaces) {
-            if (ns.has("name") && name.equals(ns.get("name").asText())) {
-                return ns.has("id") ? ns.get("id").asText() : null;
-            }
+    protected static boolean hasAvailableNamespaces(NamespaceClient nsClient) {
+        try {
+            List<JsonNode> namespaces = nsClient.list();
+            return namespaces.stream()
+                    .anyMatch(ns -> !ns.has("name") || ns.get("name").isNull());
+        } catch (Exception e) {
+            LOG.warn("Failed to check namespace availability: {}", e.getMessage());
+            return false;
         }
-        for (JsonNode ns : namespaces) {
-            if ((!ns.has("name") || ns.get("name").isNull()) && ns.has("id")) {
-                String id = ns.get("id").asText();
-                nsClient.update(id, Map.of("name", name));
-                return id;
-            }
-        }
-        LOG.warn("No pre-allocated namespace available for '{}'", name);
-        return null;
     }
 
     /**


### PR DESCRIPTION
## Summary

Follow-up to PR #149 which caused NullPointerException by updating pre-allocated namespaces via REST.

- Removed `getOrCreateNamespaceId` from `HttpToolCliITCase` and `CliResourceITCase`
- Tests now check `hasAvailableNamespaces()` (shared in `BaseIntegrationTest`) and let the CLI's `-N` flag trigger the router's internal `alocateNamespace()` which correctly assigns a pre-allocated slot backed by an MCP server instance
- Replaced `findOrAllocateNamespace()` with `hasAvailableNamespaces()` in `BaseIntegrationTest`

## Test plan

- [ ] Verify `shouldRegisterHttpToolViaCli` passes (namespace allocated on-demand by router)
- [ ] Verify `shouldExposeResourceViaCli` passes
- [ ] Verify `ForwardsCliITCase` still passes (unchanged)
- [ ] Verify no NPE on tool/resource registration

## Summary by Sourcery

Update CLI integration tests to rely on router-driven, on-demand namespace allocation instead of pre-creating and mutating namespaces via REST.

Enhancements:
- Replace BaseIntegrationTest namespace helper with a hasAvailableNamespaces() check that only verifies pre-allocated slot availability.
- Simplify HttpToolCliITCase and CliResourceITCase setup to assert namespace slot availability via NamespaceClient, removing custom getOrCreateNamespaceId helpers.