### PR TITLE
fix: add retry logic to CamelMultiInstanceITCase tool and resource calls

### DIFF
--- a/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelMultiInstanceITCase.java
+++ b/camel-integration-capability-tests/src/test/java/ai/wanaku/test/camel/CamelMultiInstanceITCase.java
@@ -47,29 +47,19 @@ class CamelMultiInstanceITCase extends CamelCapabilityTestBase {
                 .send()
                 .thenAssertResults();
 
-        mcpClient
-                .when()
-                .toolsCall("simple-greeting")
-                .withArguments(Map.of())
-                .withAssert(response -> {
-                    LOG.debug("=== MCP toolsCall response [simple-greeting]: {}", response.content());
-                    assertThat(response.isError()).isFalse();
-                    assertThat(response.content().get(0).asText().text()).contains("Hello from CIC!");
-                })
-                .send()
-                .thenAssertResults();
+        assertToolCallWithRetry("simple-greeting", Map.of(), response -> {
+            LOG.debug("=== MCP toolsCall response [simple-greeting]: {}", response.content());
+            assertThat(response.isError()).isFalse();
+            assertThat(response.content()).isNotEmpty();
+            assertThat(response.content().get(0).asText().text()).contains("Hello from CIC!");
+        });
 
-        mcpClient
-                .when()
-                .toolsCall("multi-tool")
-                .withArguments(Map.of())
-                .withAssert(response -> {
-                    LOG.debug("=== MCP toolsCall response [multi-tool]: {}", response.content());
-                    assertThat(response.isError()).isFalse();
-                    assertThat(response.content().get(0).asText().text()).contains("Response from tool instance");
-                })
-                .send()
-                .thenAssertResults();
+        assertToolCallWithRetry("multi-tool", Map.of(), response -> {
+            LOG.debug("=== MCP toolsCall response [multi-tool]: {}", response.content());
+            assertThat(response.isError()).isFalse();
+            assertThat(response.content()).isNotEmpty();
+            assertThat(response.content().get(0).asText().text()).contains("Response from tool instance");
+        });
     }
 
     @DisplayName("Run CIC tool and file resource simultaneously")
@@ -109,28 +99,27 @@ class CamelMultiInstanceITCase extends CamelCapabilityTestBase {
                 .send()
                 .thenAssertResults();
 
-        mcpClient
-                .when()
-                .toolsCall("simple-greeting")
-                .withArguments(Map.of())
-                .withAssert(response -> {
-                    LOG.debug("=== MCP toolsCall response [simple-greeting]: {}", response.content());
-                    assertThat(response.isError()).isFalse();
-                    assertThat(response.content().get(0).asText().text()).contains("Hello from CIC!");
-                })
-                .send()
-                .thenAssertResults();
+        assertToolCallWithRetry("simple-greeting", Map.of(), response -> {
+            LOG.debug("=== MCP toolsCall response [simple-greeting]: {}", response.content());
+            assertThat(response.isError()).isFalse();
+            assertThat(response.content()).isNotEmpty();
+            assertThat(response.content().get(0).asText().text()).contains("Hello from CIC!");
+        });
 
         String resourceUri = resourceServiceName + "://test-file-resource";
-        mcpClient
-                .when()
-                .resourcesRead(resourceUri)
-                .withAssert(response -> {
-                    LOG.debug("=== MCP resourcesRead response [test-file-resource]: {}", response.contents());
-                    assertThat(response.contents()).isNotEmpty();
-                    assertThat(response.contents().get(0).asText().text()).contains("Multi-instance resource content");
-                })
-                .send()
-                .thenAssertResults();
+        assertResourceReadWithRetry(() -> {
+            mcpClient
+                    .when()
+                    .resourcesRead(resourceUri)
+                    .withAssert(response -> {
+                        LOG.debug(
+                                "=== MCP resourcesRead response [test-file-resource]: {}", response.contents());
+                        assertThat(response.contents()).isNotEmpty();
+                        assertThat(response.contents().get(0).asText().text())
+                                .contains("Multi-instance resource content");
+                    })
+                    .send()
+                    .thenAssertResults();
+        });
     }
 }

--- a/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingTestBase.java
+++ b/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingTestBase.java
@@ -1,12 +1,14 @@
 package ai.wanaku.test.forward;
 
 import java.io.IOException;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ai.wanaku.test.base.BaseIntegrationTest;
 import ai.wanaku.test.client.ForwardsClient;
 import ai.wanaku.test.client.NamespaceClient;
 import ai.wanaku.test.client.RouterClient;
+import com.fasterxml.jackson.databind.JsonNode;
 import ai.wanaku.test.config.OidcCredentials;
 import ai.wanaku.test.config.TargetConfiguration;
 import ai.wanaku.test.managers.HttpCapabilityManager;
@@ -82,7 +84,16 @@ public abstract class McpForwardingTestBase extends BaseIntegrationTest {
             forwardsClient = new ForwardsClient(routerManager.getBaseUrl(), accessToken);
             namespaceClient = new NamespaceClient(routerManager.getBaseUrl(), accessToken);
             try {
-                testNamespaceId = findOrAllocateNamespace(namespaceClient, "fwd-test-ns");
+                List<JsonNode> namespaces = namespaceClient.list();
+                for (JsonNode ns : namespaces) {
+                    if (ns.has("name") && "fwd-test-ns".equals(ns.get("name").asText())) {
+                        testNamespaceId = ns.get("id").asText();
+                        break;
+                    }
+                }
+                if (testNamespaceId == null) {
+                    testNamespaceId = namespaceClient.create("fwd-test-ns", "fwd-test-ns");
+                }
             } catch (Exception e) {
                 LOG.warn("Failed to setup test namespace: {}", e.getMessage());
             }

--- a/router-tests/src/test/java/ai/wanaku/test/router/RouterTestBase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/RouterTestBase.java
@@ -1,5 +1,6 @@
 package ai.wanaku.test.router;
 
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ai.wanaku.test.base.BaseIntegrationTest;
@@ -9,6 +10,7 @@ import ai.wanaku.test.client.ManagementClient;
 import ai.wanaku.test.client.NamespaceClient;
 import ai.wanaku.test.client.PromptsClient;
 import ai.wanaku.test.client.ServiceCatalogClient;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -73,7 +75,13 @@ public abstract class RouterTestBase extends BaseIntegrationTest {
             return null;
         }
         try {
-            return findOrAllocateNamespace(namespaceClient, name);
+            List<JsonNode> namespaces = namespaceClient.list();
+            for (JsonNode ns : namespaces) {
+                if (ns.has("name") && name.equals(ns.get("name").asText())) {
+                    return ns.has("id") ? ns.get("id").asText() : null;
+                }
+            }
+            return namespaceClient.create(name, name);
         } catch (Exception e) {
             LOG.warn("Failed to get/create namespace '{}': {}", name, e.getMessage());
             return null;


### PR DESCRIPTION
## Summary

- Replaced single-shot MCP tool calls and resource reads with `assertToolCallWithRetry` and `assertResourceReadWithRetry` in `CamelMultiInstanceITCase`
- The CIC may not have Camel routes ready when the first call arrives (the `WanakuRegistrationInfoResolver` future resolves before routes start). The retry pattern (Awaitility, 90s timeout, 3s poll) handles this gracefully — same pattern used by all other Camel tests

## Test plan

- [ ] Verify `shouldRunMultipleToolsSimultaneously` passes with retry
- [ ] Verify `shouldRunToolAndResourceSimultaneously` passes with retry
- [ ] Verify no increase in test duration when CIC starts quickly

## Summary by Sourcery

Introduce retry-based assertions for MCP tool and resource interactions in Camel multi-instance integration tests to handle delayed route availability.

Enhancements:
- Replace direct MCP tool calls in CamelMultiInstanceITCase with assertToolCallWithRetry to make tests resilient to transient startup delays.
- Wrap file resource reads in CamelMultiInstanceITCase with assertResourceReadWithRetry to tolerate late resource readiness without extending fast startup runs.

Tests:
- Update multi-instance tool and resource integration tests to use shared retry helpers while preserving existing assertions on successful responses.