### PR TITLE
fix: add retry on capability deregistration assertion

### DIFF
--- a/router-tests/src/test/java/ai/wanaku/test/router/CapabilityResilienceITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/CapabilityResilienceITCase.java
@@ -69,7 +69,10 @@ class CapabilityResilienceITCase extends RouterTestBase {
         }
         routerClient.deregisterCapability("http", serviceToken);
 
-        assertThat(routerClient.isCapabilityRegistered("http")).isFalse();
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(30))
+                .pollInterval(WanakuTestConstants.DEFAULT_HEALTH_CHECK_INTERVAL)
+                .until(() -> !routerClient.isCapabilityRegistered("http"));
     }
 
     @DisplayName("Capability can re-register after being stopped and restarted")


### PR DESCRIPTION
## Summary

- `CapabilityResilienceITCase.shouldDetectCapabilityStoppage` was asserting `isCapabilityRegistered("http")` immediately after `deregisterCapability()` with no wait
- The router's service registry may take a health check cycle to reflect the deregistration, causing intermittent failures (observed 3 times in ~20 builds)
- Added Awaitility retry (30s timeout, standard health check interval) consistent with the registration wait pattern already used in the same test

## Test plan

- [ ] Verify `shouldDetectCapabilityStoppage` passes consistently
- [ ] Verify `shouldReRegisterAfterRestart` still passes

## Summary by Sourcery

Tests:
- Update shouldDetectCapabilityStoppage to await capability deregistration with a bounded retry period instead of asserting immediately.