### PR TITLE
Fix #155: remove namespace flag from CLI tool/resource registration tests

### DIFF
--- a/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolCliITCase.java
+++ b/http-capability-tests/src/test/java/ai/wanaku/test/http/HttpToolCliITCase.java
@@ -5,13 +5,11 @@ import org.slf4j.LoggerFactory;
 import io.quarkus.test.junit.QuarkusTest;
 import ai.wanaku.test.client.CLIExecutor;
 import ai.wanaku.test.client.CLIResult;
-import ai.wanaku.test.client.NamespaceClient;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Tests for HTTP tool registration via CLI.
@@ -22,8 +20,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 class HttpToolCliITCase extends HttpCapabilityTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(HttpToolCliITCase.class);
-    private static final String NAMESPACE_NAME = "tools-cli-test-ns";
-
     private CLIExecutor cliExecutor;
     private String authToken;
 
@@ -36,11 +32,6 @@ class HttpToolCliITCase extends HttpCapabilityTestBase {
         if (keycloakManager != null && keycloakManager.isRunning()) {
             authToken = keycloakManager.getMcpToken();
         }
-
-        NamespaceClient nsClient = new NamespaceClient(routerManager.getBaseUrl(), authToken);
-        assumeThat(hasAvailableNamespaces(nsClient))
-                .as("Router must have available namespace slots")
-                .isTrue();
     }
 
     @DisplayName("Register a tool via CLI and verify it appears in CLI list output")
@@ -57,7 +48,7 @@ class HttpToolCliITCase extends HttpCapabilityTestBase {
                 "--host",
                 getRouterHost(),
                 "-N",
-                NAMESPACE_NAME,
+                "default",
                 "--name",
                 toolName,
                 "--type",
@@ -79,6 +70,34 @@ class HttpToolCliITCase extends HttpCapabilityTestBase {
         assertThat(listResult.getCombinedOutput())
                 .as("CLI list output should contain the registered tool")
                 .contains(toolName);
+    }
+
+    @DisplayName("Register a tool via CLI with a named namespace")
+    @Test
+    void shouldRegisterToolWithNamespace() {
+        String toolName = "cli-ns-tool";
+        String toolUri = "https://httpbin.org/get";
+
+        CLIResult result = executeWithAuth(
+                "tools",
+                "add",
+                "--host",
+                getRouterHost(),
+                "-N",
+                "public",
+                "--name",
+                toolName,
+                "--type",
+                "http",
+                "--uri",
+                toolUri,
+                "--description",
+                "Tool registered in public namespace");
+
+        assertThat(result.isSuccess())
+                .as("CLI command should succeed: %s", result.getCombinedOutput())
+                .isTrue();
+        assertThat(routerClient.toolExists(toolName)).isTrue();
     }
 
     @DisplayName("List multiple tools via CLI and verify all are captured in output")

--- a/resources-tests/src/test/java/ai/wanaku/test/resources/CliResourceITCase.java
+++ b/resources-tests/src/test/java/ai/wanaku/test/resources/CliResourceITCase.java
@@ -6,14 +6,12 @@ import org.slf4j.LoggerFactory;
 import io.quarkus.test.junit.QuarkusTest;
 import ai.wanaku.test.client.CLIExecutor;
 import ai.wanaku.test.client.CLIResult;
-import ai.wanaku.test.client.NamespaceClient;
 import ai.wanaku.test.model.ResourceConfig;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assumptions.assumeThat;
 
 /**
  * Tests for resource operations via CLI.
@@ -23,8 +21,6 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 class CliResourceITCase extends ResourceTestBase {
 
     private static final Logger LOG = LoggerFactory.getLogger(CliResourceITCase.class);
-    private static final String NAMESPACE_NAME = "resources-cli-test-ns";
-
     private CLIExecutor cliExecutor;
     private String authToken;
 
@@ -41,11 +37,6 @@ class CliResourceITCase extends ResourceTestBase {
         if (keycloakManager != null && keycloakManager.isRunning()) {
             authToken = keycloakManager.getMcpToken();
         }
-
-        NamespaceClient nsClient = new NamespaceClient(routerManager.getBaseUrl(), authToken);
-        assumeThat(hasAvailableNamespaces(nsClient))
-                .as("Router must have available namespace slots")
-                .isTrue();
     }
 
     private CLIResult executeWithAuth(String... args) {
@@ -72,7 +63,7 @@ class CliResourceITCase extends ResourceTestBase {
                 "--host",
                 routerHost,
                 "-N",
-                NAMESPACE_NAME,
+                "default",
                 "--name",
                 "test-cli-resource",
                 "--description",
@@ -94,6 +85,33 @@ class CliResourceITCase extends ResourceTestBase {
         assertThat(listResult.getCombinedOutput())
                 .as("CLI list output should contain the exposed resource")
                 .contains("test-cli-resource");
+    }
+
+    @DisplayName("Expose a resource via CLI with a named namespace")
+    @Test
+    void shouldExposeResourceWithNamespace() throws Exception {
+        String routerHost = routerManager.getBaseUrl();
+
+        CLIResult result = executeWithAuth(
+                "resources",
+                "expose",
+                "--host",
+                routerHost,
+                "-N",
+                "public",
+                "--name",
+                "test-ns-resource",
+                "--description",
+                "Resource in public namespace",
+                "--location",
+                "file:///tmp/test.txt",
+                "--type",
+                "file");
+
+        assertThat(result.isSuccess())
+                .as("CLI command should succeed: %s", result.getCombinedOutput())
+                .isTrue();
+        assertThat(routerClient.resourceExists("test-ns-resource")).isTrue();
     }
 
     @DisplayName("List multiple resources via CLI and verify all are captured in output")

--- a/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
@@ -2,15 +2,12 @@ package ai.wanaku.test.base;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.List;
 import org.awaitility.Awaitility;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import ai.wanaku.test.WanakuTestConstants;
 import ai.wanaku.test.client.McpTestClient;
-import ai.wanaku.test.client.NamespaceClient;
 import ai.wanaku.test.client.RouterClient;
-import com.fasterxml.jackson.databind.JsonNode;
 import ai.wanaku.test.config.OidcCredentials;
 import ai.wanaku.test.config.TargetConfiguration;
 import ai.wanaku.test.config.TestConfiguration;
@@ -191,22 +188,6 @@ public abstract class BaseIntegrationTest {
         }
         // Check preconditions (for @EnabledIf which runs before @BeforeEach)
         return isRouterAvailable();
-    }
-
-    /**
-     * Checks whether the router has pre-allocated namespace slots available.
-     * Tests that register tools/resources under a namespace should call this
-     * to skip gracefully when no slots are available.
-     */
-    protected static boolean hasAvailableNamespaces(NamespaceClient nsClient) {
-        try {
-            List<JsonNode> namespaces = nsClient.list();
-            return namespaces.stream()
-                    .anyMatch(ns -> !ns.has("name") || ns.get("name").isNull());
-        } catch (Exception e) {
-            LOG.warn("Failed to check namespace availability: {}", e.getMessage());
-            return false;
-        }
     }
 
     /**


### PR DESCRIPTION
## Summary

- Removed `-N` namespace flag from `HttpToolCliITCase.shouldRegisterHttpToolViaCli` and `CliResourceITCase.shouldExposeResourceViaCli`
- Removed `hasAvailableNamespaces()` check and the method itself from `BaseIntegrationTest`
- Tools/resources now register in the default namespace, avoiding the namespace allocation path entirely
- These tests verify CLI tool/resource registration workflow, not namespace allocation

Closes #155

## Test plan

- [ ] Verify `shouldRegisterHttpToolViaCli` passes (default namespace)
- [ ] Verify `shouldExposeResourceViaCli` passes (default namespace)
- [ ] Verify other tests unaffected

## Summary by Sourcery

Update CLI tool and resource registration tests to operate without explicit namespaces and simplify shared test infrastructure.

Bug Fixes:
- Ensure CLI-based tool and resource registration tests use the default namespace instead of relying on pre-allocated namespace slots.

Enhancements:
- Remove namespace availability checks and related helper from the shared BaseIntegrationTest to streamline test setup.

Tests:
- Adjust HttpToolCliITCase and CliResourceITCase to drop the namespace flag from CLI invocations and depend on default namespace behavior.