### PR TITLE
chore: remove scheduled nightly CI job

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,10 +4,6 @@ on:
   repository_dispatch:
     types: [wanaku-build-completed]
 
-  schedule:
-    # Nightly at 03:17 UTC
-    - cron: '17 3 * * *'
-
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Summary
- Remove the nightly cron schedule trigger from the integration-tests workflow
- Tests are already triggered via `repository_dispatch` on upstream builds, making the nightly schedule redundant

## Test plan
- [ ] Verify workflow still triggers via `repository_dispatch` and `workflow_dispatch`

## Summary by Sourcery

CI:
- Remove the nightly cron schedule from the integration-tests GitHub Actions workflow to avoid redundant runs.