### PR TITLE
fix: auto-discover test modules in CI summary

### DIFF
--- a/.github/scripts/test-summary.sh
+++ b/.github/scripts/test-summary.sh
@@ -8,9 +8,15 @@ echo "|--------|------:|-------:|-------:|-------:|--------:|-----:|" >> "$GITHU
 
 total_tests=0 total_fail=0 total_err=0 total_skip=0 total_time=0
 
-for dir in */target/failsafe-reports; do
-  [ -d "$dir" ] || continue
-  module="${dir%%/target/failsafe-reports}"
+# Extract test modules from parent POM (excludes test-common which has no tests)
+modules=$(grep '<module>' pom.xml | sed 's|.*<module>\(.*\)</module>.*|\1|' | grep -v '^test-common$')
+
+for module in $modules; do
+  dir="${module}/target/failsafe-reports"
+  if [ ! -d "$dir" ]; then
+    echo "| ${module} | - | - | - | - | - | - |" >> "$GITHUB_STEP_SUMMARY"
+    continue
+  fi
 
   mod_tests=0 mod_fail=0 mod_err=0 mod_skip=0 mod_time=0
   for f in "$dir"/TEST-*.xml; do

--- a/.github/scripts/test-summary.sh
+++ b/.github/scripts/test-summary.sh
@@ -8,12 +8,9 @@ echo "|--------|------:|-------:|-------:|-------:|--------:|-----:|" >> "$GITHU
 
 total_tests=0 total_fail=0 total_err=0 total_skip=0 total_time=0
 
-for module in http-capability-tests resources-tests camel-integration-capability-tests; do
-  dir="${module}/target/failsafe-reports"
-  if [ ! -d "$dir" ]; then
-    echo "| ${module} | - | - | - | - | - | - |" >> "$GITHUB_STEP_SUMMARY"
-    continue
-  fi
+for dir in */target/failsafe-reports; do
+  [ -d "$dir" ] || continue
+  module="${dir%%/target/failsafe-reports}"
 
   mod_tests=0 mod_fail=0 mod_err=0 mod_skip=0 mod_time=0
   for f in "$dir"/TEST-*.xml; do

--- a/cross-capability-tests/pom.xml
+++ b/cross-capability-tests/pom.xml
@@ -67,7 +67,7 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-surefire-plugin</artifactId>
+                <artifactId>maven-failsafe-plugin</artifactId>
                 <configuration>
                     <runOrder>random</runOrder>
                     <systemPropertyVariables>


### PR DESCRIPTION
## Summary

- Replace hardcoded module list in `test-summary.sh` with a glob (`*/target/failsafe-reports`) so new test modules automatically appear in CI results
- Fix `cross-capability-tests/pom.xml`: change `maven-surefire-plugin` to `maven-failsafe-plugin` — its `*ITCase.java` tests were silently not running

## Context

CI run 29899204097 only showed http-capability-tests, resources-tests, and camel-integration-capability-tests in the results table. The router-tests, cross-capability-tests, and mcp-forwarding-tests modules were missing because the summary script had a hardcoded list that was never updated when those modules were added.

## Test plan

- [ ] Trigger a CI run and verify all test modules appear in the summary table
- [ ] Verify cross-capability-tests actually execute (failsafe reports generated)

## Summary by Sourcery

Auto-discover test modules in CI summary and ensure cross-capability integration tests run via Maven Failsafe.

Bug Fixes:
- Ensure cross-capability-tests integration tests are executed by switching to maven-failsafe-plugin.

Enhancements:
- Make CI test summary script dynamically discover modules by globbing failsafe report directories instead of using a hardcoded module list.

Build:
- Update cross-capability-tests Maven configuration to use maven-failsafe-plugin for integration test reporting.

CI:
- Improve test-summary.sh to iterate over all modules producing failsafe reports so new test modules are automatically included in CI summaries.