### PR TITLE
fix: pass auth token to RouterClient after router restart

### DIFF
--- a/cross-capability-tests/src/test/java/ai/wanaku/test/cross/CrossCapabilityTestBase.java
+++ b/cross-capability-tests/src/test/java/ai/wanaku/test/cross/CrossCapabilityTestBase.java
@@ -96,7 +96,11 @@ public abstract class CrossCapabilityTestBase extends BaseIntegrationTest {
         routerManager.stop();
         routerManager.start(testName);
 
-        routerClient = new RouterClient(routerManager.getBaseUrl());
+        String accessToken = null;
+        if (keycloakManager != null && keycloakManager.isRunning()) {
+            accessToken = keycloakManager.getMcpToken();
+        }
+        routerClient = new RouterClient(routerManager.getBaseUrl(), accessToken);
         if (httpPort != routerManager.getHttpPort() || grpcPort != routerManager.getGrpcPort()) {
             throw new IllegalStateException("Router restarted on different ports, reconnection would be invalid");
         }

--- a/cross-capability-tests/src/test/java/ai/wanaku/test/cross/CrossCapabilityTestBase.java
+++ b/cross-capability-tests/src/test/java/ai/wanaku/test/cross/CrossCapabilityTestBase.java
@@ -13,6 +13,7 @@ import ai.wanaku.test.config.OidcCredentials;
 import ai.wanaku.test.config.TargetConfiguration;
 import ai.wanaku.test.fixtures.TestFixtures;
 import ai.wanaku.test.managers.CamelCapabilityManager;
+import ai.wanaku.test.managers.HttpCapabilityManager;
 import ai.wanaku.test.managers.ResourceProviderManager;
 
 import org.junit.jupiter.api.AfterEach;
@@ -49,6 +50,7 @@ public abstract class CrossCapabilityTestBase extends BaseIntegrationTest {
 
         resourceProviderManager = new ResourceProviderManager(config);
         resourceProviderManager.prepare(target);
+        enablePeriodicPing(resourceProviderManager);
         resourceProviderManager.setLogContext("file-provider", getClass().getSimpleName(), "file-provider");
         resourceProviderManager.start(getClass().getSimpleName());
 
@@ -75,6 +77,7 @@ public abstract class CrossCapabilityTestBase extends BaseIntegrationTest {
                 "file://" + routesRef.toAbsolutePath(),
                 rulesRef.toFile().exists() ? "file://" + rulesRef.toAbsolutePath() : null,
                 null);
+        enablePeriodicPing(camelCapabilityManager);
         camelCapabilityManager.setLogContext("camel-capability", getClass().getSimpleName(), serviceName);
         camelCapabilityManager.start(serviceName);
 
@@ -191,6 +194,18 @@ public abstract class CrossCapabilityTestBase extends BaseIntegrationTest {
             return keycloakManager.getMcpToken();
         }
         return null;
+    }
+
+    @Override
+    protected void configureHttpCapability(HttpCapabilityManager manager) {
+        enablePeriodicPing(manager);
+    }
+
+    protected static void enablePeriodicPing(ai.wanaku.test.managers.ProcessManager manager) {
+        manager.addSystemProperty("wanaku.service.registration.ping-enabled", "true");
+        manager.addSystemProperty("wanaku.service.registration.interval", "5s");
+        manager.addEnvironmentVariable("PING_ENABLED", "true");
+        manager.addEnvironmentVariable("PERIOD", "5");
     }
 
     @Override

--- a/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
@@ -100,6 +100,7 @@ public abstract class BaseIntegrationTest {
                     testInfo.getTestClass().map(Class::getSimpleName).orElse("Unknown");
             httpCapabilityManager.setLogContext(profile, testClassName, testMethodName);
 
+            configureHttpCapability(httpCapabilityManager);
             httpCapabilityManager.start(testName);
 
             // Wait for HTTP Capability to register with Router
@@ -199,4 +200,6 @@ public abstract class BaseIntegrationTest {
     protected String getLogProfile() {
         return "default";
     }
+
+    protected void configureHttpCapability(HttpCapabilityManager manager) {}
 }

--- a/test-common/src/main/java/ai/wanaku/test/managers/ProcessManager.java
+++ b/test-common/src/main/java/ai/wanaku/test/managers/ProcessManager.java
@@ -202,6 +202,10 @@ public abstract class ProcessManager {
         jvmArgs.add("-D" + key + "=" + value);
     }
 
+    public void addEnvironmentVariable(String key, String value) {
+        environment.put(key, value);
+    }
+
     /**
      * Gets the log file for this process.
      */


### PR DESCRIPTION
## Summary

- Pass Keycloak auth token when recreating `RouterClient` in `restartRouterWithSamePorts()`

Without the token, all capability polling requests after router restart return HTTP 302 (OIDC redirect) instead of 200, so `RouterReconnectionITCase` never sees capabilities reconnect and times out after 30 seconds.

Failure observed in run [29918181417](https://github.com/orpiske/wanaku-tests/actions/runs/29918181417) — router access log shows every `GET /api/v1/capabilities` returning 302 after restart.

## Test plan

- [ ] Trigger full-integration-test with 0.2.x branches and verify `RouterReconnectionITCase` passes

## Summary by Sourcery

Ensure RouterClient is recreated with the current auth token after router restart to keep capability polling authenticated.

Bug Fixes:
- Fix router reconnection integration tests by preserving Keycloak authentication when recreating RouterClient after router restart.

Tests:
- Adjust cross-capability test router restart helper to pass Keycloak access token to the new RouterClient instance.