### PR TITLE
fix: disable shouldDeregisterCapability pending router hardening

### DIFF
--- a/router-tests/src/test/java/ai/wanaku/test/router/ServiceDiscoveryITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/ServiceDiscoveryITCase.java
@@ -9,6 +9,7 @@ import io.quarkus.test.junit.QuarkusTest;
 import ai.wanaku.test.WanakuTestConstants;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -70,6 +71,7 @@ class ServiceDiscoveryITCase extends RouterTestBase {
     }
 
     @DisplayName("Deregister a capability and verify it is no longer registered")
+    @Disabled("Blocked on wanaku-ai/wanaku#1702: deregistration endpoint needs identity verification")
     @Test
     void shouldDeregisterCapability() {
         assumeThat(isHttpToolServiceAvailable())


### PR DESCRIPTION
## Summary

- Disables `ServiceDiscoveryITCase.shouldDeregisterCapability` which fails because the router's deregistration endpoint lacks identity verification
- Tracked by wanaku-ai/wanaku#1702

## Test plan

- CI should pass with the test disabled
- Re-enable once wanaku-ai/wanaku#1702 is resolved

## Summary by Sourcery

Tests:
- Mark the ServiceDiscoveryITCase.shouldDeregisterCapability test as @Disabled due to missing identity verification on the router deregistration endpoint.