### PR TITLE
chore: fail build when too many tests are skipped

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,7 @@ wanaku-tests/
 - `wanaku.test.camel-capability.jar` - CIC JAR path
 - `wanaku.test.cli.path` - CLI path (JAR or binary)
 - `wanaku.test.timeout` - global timeout in seconds (default: 60)
+- `wanaku.test.skip.threshold` - max allowed skip percentage before build fails (default: 30)
 
 ## Test Lifecycle
 

--- a/test-common/src/main/java/ai/wanaku/test/WanakuTestConstants.java
+++ b/test-common/src/main/java/ai/wanaku/test/WanakuTestConstants.java
@@ -19,6 +19,7 @@ public final class WanakuTestConstants {
     public static final String PROP_FILE_PROVIDER_JAR = "wanaku.test.file-provider.jar";
     public static final String PROP_CAMEL_CAPABILITY_JAR = "wanaku.test.camel-capability.jar";
     public static final String PROP_TIMEOUT = "wanaku.test.timeout";
+    public static final String PROP_SKIP_THRESHOLD = "wanaku.test.skip.threshold";
 
     // Default values
     public static final String DEFAULT_ARTIFACTS_DIR = "artifacts";
@@ -26,6 +27,7 @@ public final class WanakuTestConstants {
     public static final Duration DEFAULT_TIMEOUT = Duration.ofSeconds(60);
     public static final Duration DEFAULT_HEALTH_CHECK_INTERVAL = Duration.ofMillis(200);
     public static final Duration DEFAULT_REGISTRATION_POLL_INTERVAL = Duration.ofMillis(100);
+    public static final int DEFAULT_SKIP_THRESHOLD = 30;
 
     // Health check endpoints
     public static final String ROUTER_HEALTH_PATH = "/q/health/ready";

--- a/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/BaseIntegrationTest.java
@@ -27,7 +27,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  * - Module-scoped: Keycloak, Router (shared across all test classes via {@link SharedInfrastructureExtension})
  * - Test-scoped: HttpToolService, McpClient (fresh per test)
  */
-@ExtendWith(SharedInfrastructureExtension.class)
+@ExtendWith({SharedInfrastructureExtension.class, SkipThresholdExtension.class})
 public abstract class BaseIntegrationTest {
 
     private static Logger LOG = LoggerFactory.getLogger(BaseIntegrationTest.class);

--- a/test-common/src/main/java/ai/wanaku/test/base/SkipThresholdExtension.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/SkipThresholdExtension.java
@@ -1,0 +1,110 @@
+package ai.wanaku.test.base;
+
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import ai.wanaku.test.WanakuTestConstants;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.TestWatcher;
+
+/**
+ * JUnit 5 extension that fails the build when the percentage of skipped tests
+ * exceeds a configurable threshold.
+ *
+ * <p>Tracks test outcomes (executed vs. skipped/aborted) within each Maven module's
+ * failsafe execution and checks the skip percentage when the root store is closed.
+ * Uses {@link ExtensionContext.Store.CloseableResource} so exceptions propagate
+ * reliably through maven-failsafe-plugin.
+ *
+ * <p>Configure via system property {@code wanaku.test.skip.threshold} (0–100, default 30).
+ */
+public class SkipThresholdExtension implements TestWatcher, BeforeAllCallback {
+
+    private static final ExtensionContext.Namespace NAMESPACE =
+            ExtensionContext.Namespace.create(SkipThresholdExtension.class);
+
+    @Override
+    public void beforeAll(ExtensionContext context) {
+        context.getRoot()
+                .getStore(NAMESPACE)
+                .getOrComputeIfAbsent(SkipTracker.class, key -> new SkipTracker(), SkipTracker.class);
+    }
+
+    @Override
+    public void testSuccessful(ExtensionContext context) {
+        getTracker(context).recordExecuted();
+    }
+
+    @Override
+    public void testFailed(ExtensionContext context, Throwable cause) {
+        getTracker(context).recordExecuted();
+    }
+
+    @Override
+    public void testAborted(ExtensionContext context, Throwable cause) {
+        getTracker(context).recordSkipped();
+    }
+
+    @Override
+    public void testDisabled(ExtensionContext context, Optional<String> reason) {
+        getTracker(context).recordSkipped();
+    }
+
+    private SkipTracker getTracker(ExtensionContext context) {
+        return context.getRoot()
+                .getStore(NAMESPACE)
+                .getOrComputeIfAbsent(SkipTracker.class, key -> new SkipTracker(), SkipTracker.class);
+    }
+
+    static class SkipTracker implements ExtensionContext.Store.CloseableResource {
+
+        private static final Logger LOG = LoggerFactory.getLogger(SkipTracker.class);
+
+        private final AtomicInteger executed = new AtomicInteger();
+        private final AtomicInteger skipped = new AtomicInteger();
+
+        void recordExecuted() {
+            executed.incrementAndGet();
+        }
+
+        void recordSkipped() {
+            skipped.incrementAndGet();
+        }
+
+        @Override
+        public void close() {
+            int exec = executed.get();
+            int skip = skipped.get();
+            int total = exec + skip;
+
+            if (total == 0) {
+                return;
+            }
+
+            int threshold = WanakuTestConstants.DEFAULT_SKIP_THRESHOLD;
+            String raw = System.getProperty(WanakuTestConstants.PROP_SKIP_THRESHOLD);
+            if (raw != null) {
+                try {
+                    threshold = Math.max(0, Math.min(100, Integer.parseInt(raw)));
+                } catch (NumberFormatException e) {
+                    LOG.warn(
+                            "Invalid skip threshold '{}', using default {}%",
+                            raw, WanakuTestConstants.DEFAULT_SKIP_THRESHOLD);
+                }
+            }
+
+            int skipPercent = (skip * 100) / total;
+            LOG.info("Test skip summary: {}/{} skipped ({}%), threshold {}%", skip, total, skipPercent, threshold);
+
+            // Compare without integer truncation: skip/total > threshold/100
+            if (skip * 100 > threshold * total) {
+                throw new AssertionError(String.format(
+                        "Skip threshold exceeded: %d%% of tests were skipped (%d/%d), threshold is %d%%",
+                        skipPercent, skip, total, threshold));
+            }
+        }
+    }
+}

--- a/test-common/src/main/java/ai/wanaku/test/base/SkipThresholdExtension.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/SkipThresholdExtension.java
@@ -96,7 +96,7 @@ public class SkipThresholdExtension implements TestWatcher, BeforeAllCallback {
                 }
             }
 
-            int skipPercent = (skip * 100) / total;
+            int skipPercent = skip * 100 / total;
             LOG.info("Test skip summary: {}/{} skipped ({}%), threshold {}%", skip, total, skipPercent, threshold);
 
             // Compare without integer truncation: skip/total > threshold/100


### PR DESCRIPTION
## Summary

- Adds `SkipThresholdExtension` (JUnit 5 `TestWatcher` + `BeforeAllCallback`) that counts executed vs. skipped/aborted tests per module and throws `AssertionError` when the skip rate exceeds the threshold
- Configurable via `-Dwanaku.test.skip.threshold=N` (0–100, default 30%)
- Uses `CloseableResource` in the root extension store so failures propagate through failsafe
- Handles malformed property values gracefully (logs warning, falls back to default)

## Test plan

- [ ] Verify `mvn -DskipTests compile -pl test-common` compiles cleanly
- [ ] Run `mvn verify -pl resources-tests` with artifacts present — confirm skip summary is logged
- [ ] Run with `-Dwanaku.test.skip.threshold=0` and confirm build fails when any test is skipped
- [ ] Run with `-Dwanaku.test.skip.threshold=100` and confirm build passes regardless of skips
- [ ] Run with `-Dwanaku.test.skip.threshold=invalid` and confirm warning is logged with default fallback

## Summary by Sourcery

Introduce a JUnit 5 extension to enforce a maximum test skip rate and integrate it into the shared integration test base.

New Features:
- Add a configurable skip-threshold JUnit 5 extension that tracks executed vs. skipped tests and fails the build when the skip percentage exceeds the threshold.

Enhancements:
- Centralize configuration for the skip threshold with new test constants and sensible defaults.

Documentation:
- Document the wanaku.test.skip.threshold system property and its default behavior in CLAUDE.md.