### PR TITLE
Add PR comment-back support to integration test workflow

### DIFF
--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -35,6 +35,17 @@ on:
         description: 'Wanaku Examples branch'
         required: false
         default: 'main'
+      pr_number:
+        description: 'PR number to comment results on (empty = skip commenting)'
+        required: false
+        default: ''
+      source_repo:
+        description: 'Source repository for PR comment (owner/repo)'
+        required: false
+        default: 'wanaku-ai/wanaku'
+
+permissions:
+  contents: read
 
 jobs:
   full-integration-test:
@@ -49,6 +60,8 @@ jobs:
       CIC_BRANCH: ${{ inputs.cic_branch }}
       EXAMPLES_REPO: ${{ inputs.examples_repo }}
       EXAMPLES_BRANCH: ${{ inputs.examples_branch }}
+      PR_NUMBER: ${{ inputs.pr_number }}
+      SOURCE_REPO: ${{ inputs.source_repo }}
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -169,6 +182,56 @@ jobs:
       - name: Test summary
         if: always()
         run: ./.github/scripts/test-summary.sh
+
+      - name: Resolve source repo name
+        if: always() && env.PR_NUMBER != ''
+        id: source
+        run: |
+          REPO_NAME="${SOURCE_REPO#*/}"
+          if [ -z "$REPO_NAME" ] || [ "$REPO_NAME" = "$SOURCE_REPO" ]; then
+            echo "::error::Invalid source_repo format '${SOURCE_REPO}' — expected 'owner/repo'"
+            exit 1
+          fi
+          echo "repo_name=${REPO_NAME}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate GitHub App token
+        if: always() && env.PR_NUMBER != ''
+        id: app-token
+        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        with:
+          app-id: ${{ secrets.INTEGRATION_APP_ID }}
+          private-key: ${{ secrets.INTEGRATION_APP_PRIVATE_KEY }}
+          owner: wanaku-ai
+          repositories: ${{ steps.source.outputs.repo_name }}
+
+      - name: Post test summary to PR
+        if: always() && env.PR_NUMBER != '' && steps.app-token.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          MARKER="<!-- integration-test-results -->"
+          RUN_URL="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+          {
+            echo "${MARKER}"
+            echo "## Integration Test Results"
+            echo ""
+            echo "> **Run:** [${RUN_URL}](${RUN_URL})"
+            echo "> **Wanaku:** \`${WANAKU_REPO}\` @ \`${WANAKU_BRANCH}\`"
+            echo ""
+            cat "$GITHUB_STEP_SUMMARY"
+          } > pr-comment.md
+
+          EXISTING=$(gh api --paginate "repos/${SOURCE_REPO}/issues/${PR_NUMBER}/comments" \
+            --jq ".[] | select(.body | startswith(\"${MARKER}\")) | .id" | head -1)
+
+          if [ -n "$EXISTING" ]; then
+            gh api "repos/${SOURCE_REPO}/issues/comments/${EXISTING}" \
+              -X PATCH -F "body=@pr-comment.md"
+          else
+            gh api "repos/${SOURCE_REPO}/issues/${PR_NUMBER}/comments" \
+              -F "body=@pr-comment.md"
+          fi
 
       - name: Upload test reports
         if: always()


### PR DESCRIPTION
## Summary

- Adds `pr_number` and `source_repo` inputs to `full-integration-test.yml` (backward-compatible, both optional with defaults)
- After tests complete, mints a GitHub App token and posts the test summary as a comment on the originating PR in the source repo
- Uses idempotent upsert (HTML marker `<!-- integration-test-results -->`) so re-triggers update the existing comment instead of creating duplicates
- Adds `permissions: contents: read` for least-privilege defaults

## Required setup

- Store `INTEGRATION_APP_ID` and `INTEGRATION_APP_PRIVATE_KEY` as repo/org secrets
- GitHub App needs `pull-requests: write` permission on `wanaku-ai/wanaku`

## Companion PR

The dispatch side (triggering from a PR comment in wanaku) is at https://github.com/wanaku-ai/wanaku/pull/1732

## Test plan

- [ ] Manually trigger `full-integration-test` with `pr_number` and `source_repo` inputs
- [ ] Verify test summary comment appears on the target PR
- [ ] Re-trigger and verify the comment is updated (not duplicated)
- [ ] Trigger without `pr_number` and verify no comment step runs (backward compatibility)

## Summary by Sourcery

Add optional PR context inputs to the full integration test workflow and report results back to the originating pull request as a comment using a GitHub App token.

Enhancements:
- Allow the integration test workflow to accept optional PR number and source repository inputs while remaining backward compatible.
- Post an idempotent integration test summary comment to the specified pull request using a GitHub App token, updating an existing comment when rerun.
- Tighten workflow permissions by granting read-only access to repository contents.