### PR TITLE
Update create-github-app-token to v3.2.0

### DIFF
--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -197,7 +197,7 @@ jobs:
       - name: Generate GitHub App token
         if: always() && env.PR_NUMBER != ''
         id: app-token
-        uses: actions/create-github-app-token@fee1f7d63c2ff003460e3d139729b119787bc349 # v2.2.2
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           app-id: ${{ secrets.INTEGRATION_APP_ID }}
           private-key: ${{ secrets.INTEGRATION_APP_PRIVATE_KEY }}


### PR DESCRIPTION
## Summary

- Update `actions/create-github-app-token` from v2.2.2 to v3.2.0
- Node 20 is deprecated on GitHub Actions runners; v3.2.0 supports Node 24

## Test plan

- [ ] Merge and re-test integration test dispatch from wanaku PR

## Summary by Sourcery

Build:
- Bump actions/create-github-app-token in the full integration test workflow from v2.2.2 to v3.2.0.