### PR TITLE
Use client-id for create-github-app-token v3

### DIFF
--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -199,7 +199,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.INTEGRATION_APP_ID }}
+          client-id: ${{ secrets.INTEGRATION_APP_CLIENT_ID }}
           private-key: ${{ secrets.INTEGRATION_APP_PRIVATE_KEY }}
           owner: wanaku-ai
           repositories: ${{ steps.source.outputs.repo_name }}


### PR DESCRIPTION
## Summary

- `create-github-app-token` v3.x deprecated `app-id` in favor of `client-id`
- The secret should be `INTEGRATION_APP_CLIENT_ID` containing the GitHub App Client ID string (starts with `Iv`)

## Test plan

- [ ] Merge, then test integration test dispatch from wanaku

## Summary by Sourcery

Build:
- Switch full integration test workflow to pass INTEGRATION_APP_CLIENT_ID as client-id to create-github-app-token action.