### PR TITLE
fix: collect CIC main module JAR instead of plugin shaded JAR

### DIFF
--- a/.github/scripts/collect-from-source-artifacts.sh
+++ b/.github/scripts/collect-from-source-artifacts.sh
@@ -55,9 +55,10 @@ fi
 # File Provider from wanaku-examples
 collect_quarkus_app "$SOURCE_DIR/wanaku-examples" "wanaku-provider-file" "wanaku-provider-file"
 
-# Camel Integration Capability (fat JAR — may use assembly-plugin or shade-plugin)
-CIC_JAR=$(find "$SOURCE_DIR/camel-integration-capability" -path "*/target/*" \
-    \( -name "*-jar-with-dependencies.jar" -o -name "*-shaded.jar" -o -name "*-runner.jar" \) \
+# Camel Integration Capability (fat JAR from the -main module, not the -plugin module)
+CIC_JAR=$(find "$SOURCE_DIR/camel-integration-capability" \
+    -path "*/camel-integration-capability-main/target/*" \
+    -name "*-jar-with-dependencies.jar" \
     2>/dev/null | head -1)
 
 if [ -n "$CIC_JAR" ]; then


### PR DESCRIPTION
## Summary

- The `collect-from-source-artifacts.sh` script was collecting the wrong CIC JAR: it picked up the **plugin** module's shaded JAR (`camel-integration-capability-plugin-*-shaded.jar`) instead of the **main** module's assembly JAR (`camel-integration-capability-main-*-jar-with-dependencies.jar`).
- The plugin module is a `ContextServicePlugin` for embedding into existing Camel apps — it has no `Main-Class` manifest attribute and is not meant to run standalone.
- This caused all 16 CIC integration tests to fail with `"no main manifest attribute"` followed by a 63-second health check timeout.
- The fix targets the `-main` module path specifically.

## Test plan

- [ ] Trigger `full-integration-test.yml` and verify CIC tests pass

## Summary by Sourcery

Bug Fixes:
- Fix CIC artifact discovery to avoid selecting the plugin shaded JAR without a main manifest by targeting the main module's fat JAR explicitly.