### PR TITLE
feat: add labels support to DataStoreClient and test upload with labels

### DIFF
--- a/router-tests/src/test/java/ai/wanaku/test/router/DataStoreCrudITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/DataStoreCrudITCase.java
@@ -2,7 +2,9 @@ package ai.wanaku.test.router;
 
 import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Map;
 import io.quarkus.test.junit.QuarkusTest;
+import com.fasterxml.jackson.databind.JsonNode;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -104,14 +106,29 @@ class DataStoreCrudITCase extends RouterTestBase {
                 .isEqualTo(textContent);
     }
 
-    @DisplayName("Upload with labels is not supported by client API - skip")
+    @DisplayName("Upload an entry with labels and verify labels are persisted")
     @Test
     void shouldUploadEntryWithLabels() {
-        // The DataStoreClient.upload() hardcodes empty labels.
-        // This test verifies basic upload still works (labels feature untested at client level).
-        assumeThat(false)
-                .as("DataStoreClient does not expose a labels parameter")
+        String name = "labeled-entry.txt";
+        Map<String, String> labels = Map.of("environment", "test", "component", "router");
+
+        dataStoreClient.upload(name, "labeled content", labels);
+
+        String downloaded = dataStoreClient.download(name);
+        assertThat(downloaded)
+                .as("Data content should survive labels round-trip")
+                .isEqualTo("labeled content");
+
+        JsonNode entry = dataStoreClient.downloadEntry(name);
+        assertThat(entry.has("labels"))
+                .as("Response should contain labels field")
                 .isTrue();
+
+        JsonNode labelsNode = entry.get("labels");
+        assertThat(labelsNode.has("environment")).isTrue();
+        assertThat(labelsNode.get("environment").asText()).isEqualTo("test");
+        assertThat(labelsNode.has("component")).isTrue();
+        assertThat(labelsNode.get("component").asText()).isEqualTo("router");
     }
 
     @DisplayName("DataStore rejects duplicate entry names with 409")

--- a/router-tests/src/test/java/ai/wanaku/test/router/NamespaceCliITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/NamespaceCliITCase.java
@@ -32,8 +32,8 @@ class NamespaceCliITCase extends RouterTestBase {
     void shouldCreateNamespaceViaCli() {
         String name = "test-cli-ns";
 
-        CLIResult result = executeWithAuth(
-                "namespaces", "create", "--host", getRouterHost(), "--name", name, "--path", name);
+        CLIResult result =
+                executeWithAuth("namespaces", "create", "--host", getRouterHost(), "--name", name, "--path", name);
 
         assertThat(result.isSuccess())
                 .as("CLI command should succeed: %s", result.getCombinedOutput())

--- a/test-common/src/main/java/ai/wanaku/test/client/DataStoreClient.java
+++ b/test-common/src/main/java/ai/wanaku/test/client/DataStoreClient.java
@@ -63,6 +63,17 @@ public class DataStoreClient {
     }
 
     /**
+     * Uploads a string content entry with labels to the data store.
+     *
+     * @param name the entry name (e.g., "routes.yaml")
+     * @param content the string content to upload
+     * @param labels the labels to attach to the entry
+     */
+    public void upload(String name, String content, Map<String, String> labels) {
+        upload(name, content.getBytes(StandardCharsets.UTF_8), labels);
+    }
+
+    /**
      * Uploads a byte array content entry to the data store.
      * The content is base64-encoded before sending.
      *
@@ -70,14 +81,27 @@ public class DataStoreClient {
      * @param content the byte array content to upload
      */
     public void upload(String name, byte[] content) {
-        LOG.debug("Uploading data store entry: {}", name);
+        upload(name, content, Map.of());
+    }
+
+    /**
+     * Uploads a byte array content entry with labels to the data store.
+     * The content is base64-encoded before sending.
+     *
+     * @param name the entry name (e.g., "routes.yaml")
+     * @param content the byte array content to upload
+     * @param labels the labels to attach to the entry
+     */
+    public void upload(String name, byte[] content, Map<String, String> labels) {
+        Map<String, String> safeLabels = labels != null ? labels : Map.of();
+        LOG.debug("Uploading data store entry: {} with {} labels", name, safeLabels.size());
 
         String encoded = Base64.getEncoder().encodeToString(content);
 
         Map<String, Object> body = new HashMap<>();
         body.put("name", name);
         body.put("data", encoded);
-        body.put("labels", Map.of());
+        body.put("labels", safeLabels);
 
         try {
             String json = objectMapper.writeValueAsString(body);
@@ -100,6 +124,60 @@ public class DataStoreClient {
                 Thread.currentThread().interrupt();
             }
             throw new DataStoreClientException("Failed to upload data store entry", e);
+        }
+    }
+
+    /**
+     * Downloads an entry from the data store by name, returning data and labels.
+     *
+     * @param name the entry name to download
+     * @return the entry as a JsonNode containing data and labels fields
+     * @throws DataStoreEntryNotFoundException if no entry with the given name is found
+     */
+    public JsonNode downloadEntry(String name) {
+        LOG.debug("Downloading data store entry (full): {}", name);
+
+        try {
+            String encodedName = URLEncoder.encode(name, StandardCharsets.UTF_8);
+            HttpRequest request = buildRequest(WanakuTestConstants.ROUTER_DATA_STORE_PATH + "?name=" + encodedName)
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            if (response.statusCode() == 200) {
+                JsonNode root = objectMapper.readTree(response.body());
+
+                if (root.has("error") && !root.get("error").isNull()) {
+                    String errorMsg = root.get("error").has("message")
+                            ? root.get("error").get("message").asText()
+                            : root.get("error").asText();
+                    throw new DataStoreEntryNotFoundException("Entry '" + name + "' not found: " + errorMsg);
+                }
+
+                JsonNode dataNode = root.has("data") ? root.get("data") : root;
+                if (dataNode == null || dataNode.isNull()) {
+                    throw new DataStoreEntryNotFoundException("Entry '" + name + "' not found");
+                }
+
+                if (dataNode.isArray()) {
+                    if (dataNode.isEmpty()) {
+                        throw new DataStoreEntryNotFoundException("Entry '" + name + "' not found");
+                    }
+                    return dataNode.get(0);
+                }
+                return dataNode;
+            } else if (response.statusCode() == 404) {
+                throw new DataStoreEntryNotFoundException("Entry '" + name + "' not found");
+            } else {
+                throw new DataStoreClientException(
+                        "Failed to download data store entry: " + response.statusCode() + " - " + response.body());
+            }
+        } catch (IOException | InterruptedException e) {
+            if (e instanceof InterruptedException) {
+                Thread.currentThread().interrupt();
+            }
+            throw new DataStoreClientException("Failed to download data store entry", e);
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `upload(name, content, labels)` overloads to `DataStoreClient` so labels can be passed to the Data Store API
- Add `downloadEntry(name)` method that returns the full `JsonNode` (including labels) instead of just the decoded data string
- Replace the hardcoded-skip placeholder `shouldUploadEntryWithLabels` test with a real test that uploads with labels and verifies both data integrity and label persistence
- Null-safe labels parameter handling in the upload path

## Test plan

- [ ] Trigger `full-integration-test.yml` and verify `shouldUploadEntryWithLabels` passes (was previously always skipped)
- [ ] Verify other `DataStoreCrudITCase` tests still pass

## Summary by Sourcery

Add label-aware uploads to the DataStore test client and cover label persistence in integration tests.

New Features:
- Allow uploading data store entries with string or byte content and attached labels via DataStoreClient.
- Expose a downloadEntry API on DataStoreClient to retrieve full entry metadata including labels.

Enhancements:
- Handle null label maps safely in the DataStoreClient upload path.
- Enable and extend the data store CRUD integration test to verify label round-trip persistence for uploaded entries.
- Tidy namespace CLI integration test formatting without changing behavior.

Tests:
- Replace the placeholder upload-with-labels test with a real integration test that asserts both data integrity and label persistence via DataStoreClient.