### PR TITLE
fix: exclude known-limitation tests from skip threshold ratio

### DIFF
--- a/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingBasicITCase.java
+++ b/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingBasicITCase.java
@@ -2,6 +2,7 @@ package ai.wanaku.test.forward;
 
 import java.util.List;
 import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.base.KnownLimitation;
 import ai.wanaku.test.client.ForwardsClient;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -43,6 +44,7 @@ class McpForwardingBasicITCase extends McpForwardingTestBase {
         return false;
     }
 
+    @KnownLimitation("wanaku#1741")
     @DisplayName("Add a forward to the target MCP server")
     @Test
     void shouldAddForward() {
@@ -62,6 +64,7 @@ class McpForwardingBasicITCase extends McpForwardingTestBase {
         assertThat(forwards).isNotNull();
     }
 
+    @KnownLimitation("wanaku#1741")
     @DisplayName("Remove a forward and verify it no longer exists")
     @Test
     void shouldRemoveForward() {
@@ -82,6 +85,7 @@ class McpForwardingBasicITCase extends McpForwardingTestBase {
         assertThat(removed).isFalse();
     }
 
+    @KnownLimitation("wanaku#1741")
     @DisplayName("Refresh a forward without error")
     @Test
     void shouldRefreshForwards() {

--- a/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingErrorITCase.java
+++ b/mcp-forwarding-tests/src/test/java/ai/wanaku/test/forward/McpForwardingErrorITCase.java
@@ -2,6 +2,7 @@ package ai.wanaku.test.forward;
 
 import java.util.List;
 import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.base.KnownLimitation;
 import ai.wanaku.test.client.ForwardsClient;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -31,6 +32,7 @@ class McpForwardingErrorITCase extends McpForwardingTestBase {
         }
     }
 
+    @KnownLimitation("wanaku#1741")
     @DisplayName("Adding a forward with a valid target succeeds")
     @Test
     void shouldAddForwardWithValidTarget() {

--- a/router-tests/src/test/java/ai/wanaku/test/router/ForwardsCliITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/ForwardsCliITCase.java
@@ -1,6 +1,7 @@
 package ai.wanaku.test.router;
 
 import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.base.KnownLimitation;
 import ai.wanaku.test.client.CLIExecutor;
 import ai.wanaku.test.client.CLIResult;
 
@@ -31,6 +32,7 @@ class ForwardsCliITCase extends RouterTestBase {
         assumeThat(nsId).as("Test namespace must be available").isNotNull();
     }
 
+    @KnownLimitation("wanaku#1741")
     @DisplayName("Add a forward via CLI and verify it exists via REST")
     @Test
     void shouldAddForwardViaCli() {
@@ -67,6 +69,7 @@ class ForwardsCliITCase extends RouterTestBase {
                 .isTrue();
     }
 
+    @KnownLimitation("wanaku#1741")
     @DisplayName("Remove a forward via CLI")
     @Test
     void shouldRemoveForwardViaCli() {

--- a/router-tests/src/test/java/ai/wanaku/test/router/ForwardsCrudITCase.java
+++ b/router-tests/src/test/java/ai/wanaku/test/router/ForwardsCrudITCase.java
@@ -2,6 +2,7 @@ package ai.wanaku.test.router;
 
 import java.util.List;
 import io.quarkus.test.junit.QuarkusTest;
+import ai.wanaku.test.base.KnownLimitation;
 import ai.wanaku.test.client.ForwardsClient;
 import com.fasterxml.jackson.databind.JsonNode;
 
@@ -35,6 +36,7 @@ class ForwardsCrudITCase extends RouterTestBase {
         }
     }
 
+    @KnownLimitation("wanaku#1741")
     @DisplayName("Add a forward and verify it exists")
     @Test
     void shouldAddForward() {
@@ -59,6 +61,7 @@ class ForwardsCrudITCase extends RouterTestBase {
         assertThat(removed).isFalse();
     }
 
+    @KnownLimitation("wanaku#1741")
     @DisplayName("Remove a forward and verify it no longer exists")
     @Test
     void shouldRemoveForward() {
@@ -73,6 +76,7 @@ class ForwardsCrudITCase extends RouterTestBase {
         assertThat(forwardsClient.exists("fwd-to-remove")).isFalse();
     }
 
+    @KnownLimitation("wanaku#1741")
     @DisplayName("Refresh a forward without error")
     @Test
     void shouldRefreshForwards() {

--- a/test-common/src/main/java/ai/wanaku/test/base/KnownLimitation.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/KnownLimitation.java
@@ -1,0 +1,20 @@
+package ai.wanaku.test.base;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a test that is expected to skip due to a known product limitation.
+ * Skips from annotated tests are excluded from the {@link SkipThresholdExtension} ratio.
+ */
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface KnownLimitation {
+
+    /**
+     * Reference to the tracking issue (e.g., "wanaku#1741").
+     */
+    String value();
+}

--- a/test-common/src/main/java/ai/wanaku/test/base/SkipThresholdExtension.java
+++ b/test-common/src/main/java/ai/wanaku/test/base/SkipThresholdExtension.java
@@ -45,12 +45,26 @@ public class SkipThresholdExtension implements TestWatcher, BeforeAllCallback {
 
     @Override
     public void testAborted(ExtensionContext context, Throwable cause) {
-        getTracker(context).recordSkipped();
+        if (isKnownLimitation(context)) {
+            getTracker(context).recordExcluded();
+        } else {
+            getTracker(context).recordSkipped();
+        }
     }
 
     @Override
     public void testDisabled(ExtensionContext context, Optional<String> reason) {
-        getTracker(context).recordSkipped();
+        if (isKnownLimitation(context)) {
+            getTracker(context).recordExcluded();
+        } else {
+            getTracker(context).recordSkipped();
+        }
+    }
+
+    private boolean isKnownLimitation(ExtensionContext context) {
+        return context.getTestMethod()
+                .map(m -> m.isAnnotationPresent(KnownLimitation.class))
+                .orElse(false);
     }
 
     private SkipTracker getTracker(ExtensionContext context) {
@@ -65,6 +79,7 @@ public class SkipThresholdExtension implements TestWatcher, BeforeAllCallback {
 
         private final AtomicInteger executed = new AtomicInteger();
         private final AtomicInteger skipped = new AtomicInteger();
+        private final AtomicInteger excluded = new AtomicInteger();
 
         void recordExecuted() {
             executed.incrementAndGet();
@@ -72,6 +87,10 @@ public class SkipThresholdExtension implements TestWatcher, BeforeAllCallback {
 
         void recordSkipped() {
             skipped.incrementAndGet();
+        }
+
+        void recordExcluded() {
+            excluded.incrementAndGet();
         }
 
         @Override
@@ -96,14 +115,28 @@ public class SkipThresholdExtension implements TestWatcher, BeforeAllCallback {
                 }
             }
 
-            int skipPercent = skip * 100 / total;
-            LOG.info("Test skip summary: {}/{} skipped ({}%), threshold {}%", skip, total, skipPercent, threshold);
+            int excl = excluded.get();
+            int countedTotal = exec + skip;
 
-            // Compare without integer truncation: skip/total > threshold/100
-            if (skip * 100 > threshold * total) {
+            if (excl > 0) {
+                LOG.info(
+                        "Test skip summary: {}/{} skipped ({}%), {} excluded (@KnownLimitation), threshold {}%",
+                        skip, countedTotal, countedTotal > 0 ? skip * 100 / countedTotal : 0, excl, threshold);
+            } else {
+                LOG.info(
+                        "Test skip summary: {}/{} skipped ({}%), threshold {}%",
+                        skip, countedTotal, countedTotal > 0 ? skip * 100 / countedTotal : 0, threshold);
+            }
+
+            if (countedTotal == 0) {
+                return;
+            }
+
+            // Compare without integer truncation: skip/countedTotal > threshold/100
+            if (skip * 100 > threshold * countedTotal) {
                 throw new AssertionError(String.format(
                         "Skip threshold exceeded: %d%% of tests were skipped (%d/%d), threshold is %d%%",
-                        skipPercent, skip, total, threshold));
+                        skip * 100 / countedTotal, skip, countedTotal, threshold));
             }
         }
     }


### PR DESCRIPTION
## Summary

- Add `@KnownLimitation("issue-ref")` annotation for tests that skip due to tracked product issues
- Update `SkipThresholdExtension` to exclude annotated tests from the skip ratio calculation — they are logged separately but don't count toward the threshold
- Annotate 9 forwarding tests blocked on [wanaku#1741](https://github.com/wanaku-ai/wanaku/issues/1741) (MCP forwarding does not propagate OIDC credentials)
- The 30% default threshold stays unchanged — only expected skips are excluded, so unexpected regressions still fail the build

## Test plan

- [ ] Trigger `full-integration-test.yml` and verify the build passes (mcp-forwarding-tests no longer fails the SkipThresholdExtension guard)
- [ ] Verify the log output shows excluded tests separately from counted skips

## Summary by Sourcery

Exclude tests marked as known product limitations from the skip threshold calculation and annotate forwarding-related tests blocked by a tracked issue.

Enhancements:
- Adjust skip-threshold tracking and logging to account separately for excluded known-limitation tests.

Tests:
- Annotate forwarding and router tests affected by wanaku#1741 as known limitations so their skips no longer contribute to the skip ratio.