### PR TITLE
ci: remove dead Java build step from full-integration-test

### DIFF
--- a/.github/scripts/collect-from-source-artifacts.sh
+++ b/.github/scripts/collect-from-source-artifacts.sh
@@ -4,6 +4,7 @@
 # in the layout expected by the test framework (TestConfiguration).
 #
 # Expected source layout (created by the CI workflow):
+#   source/wanaku-barn/                  -> wanaku-cli (native binary or Quarkus app)
 #   source/camel-integration-capability/ -> camel-integration-capability-main fat JAR
 #
 
@@ -13,6 +14,27 @@ ARTIFACTS_DIR="$(pwd)/artifacts"
 SOURCE_DIR="$(pwd)/source"
 
 mkdir -p "$ARTIFACTS_DIR"
+
+# CLI from wanaku-barn (may be a native binary or a Quarkus app)
+CLI_NATIVE=$(find "$SOURCE_DIR/wanaku-barn" -type f -name "wanaku" \
+    -path "*/wanaku-cli/target/*" ! -name "*.jar" 2>/dev/null | head -1)
+
+if [ -n "$CLI_NATIVE" ]; then
+    echo "Collecting CLI (native) from ${CLI_NATIVE}"
+    mkdir -p "${ARTIFACTS_DIR}/wanaku-cli/bin"
+    cp "$CLI_NATIVE" "${ARTIFACTS_DIR}/wanaku-cli/bin/wanaku"
+    chmod +x "${ARTIFACTS_DIR}/wanaku-cli/bin/wanaku"
+else
+    CLI_QUARKUS=$(find "$SOURCE_DIR/wanaku-barn" -type d -name "quarkus-app" \
+        -path "*/wanaku-cli/target/*" 2>/dev/null | head -1)
+    if [ -n "$CLI_QUARKUS" ]; then
+        echo "Collecting CLI (Quarkus) from ${CLI_QUARKUS}"
+        mkdir -p "${ARTIFACTS_DIR}/wanaku-cli"
+        cp -r "$CLI_QUARKUS"/* "${ARTIFACTS_DIR}/wanaku-cli/"
+    else
+        echo "::warning::Could not find CLI in wanaku-barn build output"
+    fi
+fi
 
 # Camel Integration Capability (fat JAR from the -main module, not the -plugin module)
 CIC_JAR=$(find "$SOURCE_DIR/camel-integration-capability" \

--- a/.github/scripts/collect-from-source-artifacts.sh
+++ b/.github/scripts/collect-from-source-artifacts.sh
@@ -1,11 +1,9 @@
 #!/bin/bash
 #
 # Collects build outputs from source checkouts into the artifacts/ directory
-# in the layout expected by the test framework (TestConfiguration.findJar).
+# in the layout expected by the test framework (TestConfiguration).
 #
 # Expected source layout (created by the CI workflow):
-#   source/wanaku/             -> wanaku-router-backend, wanaku-tool-service-http, wanaku-cli
-#   source/wanaku-examples/    -> wanaku-provider-file
 #   source/camel-integration-capability/ -> camel-integration-capability-main fat JAR
 #
 
@@ -15,45 +13,6 @@ ARTIFACTS_DIR="$(pwd)/artifacts"
 SOURCE_DIR="$(pwd)/source"
 
 mkdir -p "$ARTIFACTS_DIR"
-
-collect_quarkus_app() {
-    local source_root="$1"
-    local module_name="$2"
-    local target_name="$3"
-
-    local quarkus_app
-    quarkus_app=$(find "$source_root" -type d -name "quarkus-app" \
-        -path "*/${module_name}/target/*" 2>/dev/null | head -1)
-
-    if [ -z "$quarkus_app" ]; then
-        echo "::warning::Could not find quarkus-app for ${target_name} (module: ${module_name})"
-        return 1
-    fi
-
-    echo "Collecting ${target_name} from ${quarkus_app}"
-    mkdir -p "${ARTIFACTS_DIR}/${target_name}"
-    cp -r "$quarkus_app"/* "${ARTIFACTS_DIR}/${target_name}/"
-}
-
-# Router and HTTP Tool Service from wanaku
-collect_quarkus_app "$SOURCE_DIR/wanaku" "wanaku-router-backend" "wanaku-router-backend"
-collect_quarkus_app "$SOURCE_DIR/wanaku" "wanaku-tool-service-http" "wanaku-tool-service-http"
-
-# CLI from wanaku (may be a Quarkus app or a native binary)
-CLI_NATIVE=$(find "$SOURCE_DIR/wanaku" -type f -name "wanaku" \
-    -path "*/wanaku-cli/target/*" ! -path "*.jar" 2>/dev/null | head -1)
-
-if [ -n "$CLI_NATIVE" ]; then
-    echo "Collecting CLI (native) from ${CLI_NATIVE}"
-    mkdir -p "${ARTIFACTS_DIR}/wanaku-cli/bin"
-    cp "$CLI_NATIVE" "${ARTIFACTS_DIR}/wanaku-cli/bin/wanaku"
-    chmod +x "${ARTIFACTS_DIR}/wanaku-cli/bin/wanaku"
-else
-    collect_quarkus_app "$SOURCE_DIR/wanaku" "wanaku-cli" "wanaku-cli" || true
-fi
-
-# File Provider from wanaku-examples
-collect_quarkus_app "$SOURCE_DIR/wanaku-examples" "wanaku-provider-file" "wanaku-provider-file"
 
 # Camel Integration Capability (fat JAR from the -main module, not the -plugin module)
 CIC_JAR=$(find "$SOURCE_DIR/camel-integration-capability" \

--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -104,14 +104,6 @@ jobs:
             mvn -B -DskipTests install -f source/wanaku-sdk/pom.xml
           fi
 
-      - name: Build Wanaku (Java components)
-        run: |
-          if [ -x source/wanaku/mvnw ]; then
-            source/wanaku/mvnw -B -DskipTests install -f source/wanaku/pom.xml
-          else
-            mvn -B -DskipTests install -f source/wanaku/pom.xml
-          fi
-
       - name: Build Wanaku Praxis (Rust)
         run: |
           cd source/wanaku

--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -150,11 +150,15 @@ jobs:
       - name: Resolve CLI path
         id: cli
         run: |
-          CLI_PATH=$(find source/wanaku-barn -name "quarkus-run.jar" -path "*wanaku-cli*/quarkus-app/*" 2>/dev/null | head -1)
+          CLI_PATH=$(find artifacts -name "wanaku" -path "*/bin/*" -type f 2>/dev/null | head -1)
+          if [ -z "$CLI_PATH" ]; then
+            CLI_PATH=$(find artifacts -name "quarkus-run.jar" -path "*wanaku-cli*" 2>/dev/null | head -1)
+          fi
           if [ -n "$CLI_PATH" ]; then
+            chmod +x "$CLI_PATH" 2>/dev/null || true
             echo "path=$(pwd)/${CLI_PATH}" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::CLI not found in wanaku-barn build output"
+            echo "::warning::CLI not found in built artifacts"
           fi
 
       - name: Run integration tests

--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -27,6 +27,14 @@ on:
         description: 'Camel Integration Capability branch'
         required: false
         default: 'main'
+      barn_repo:
+        description: 'Wanaku Barn repository (owner/repo)'
+        required: false
+        default: 'wanaku-ai/wanaku-barn'
+      barn_branch:
+        description: 'Wanaku Barn branch'
+        required: false
+        default: 'main'
       pr_number:
         description: 'PR number to comment results on (empty = skip commenting)'
         required: false
@@ -50,6 +58,8 @@ jobs:
       SDK_BRANCH: ${{ inputs.sdk_branch }}
       CIC_REPO: ${{ inputs.cic_repo }}
       CIC_BRANCH: ${{ inputs.cic_branch }}
+      BARN_REPO: ${{ inputs.barn_repo }}
+      BARN_BRANCH: ${{ inputs.barn_branch }}
       PR_NUMBER: ${{ inputs.pr_number }}
       SOURCE_REPO: ${{ inputs.source_repo }}
     steps:
@@ -84,6 +94,11 @@ jobs:
             "https://github.com/${CIC_REPO}.git" source/camel-integration-capability
           echo "::endgroup::"
 
+          echo "::group::Cloning Barn (${BARN_REPO}@${BARN_BRANCH})"
+          git clone --depth 1 --branch "${BARN_BRANCH}" \
+            "https://github.com/${BARN_REPO}.git" source/wanaku-barn
+          echo "::endgroup::"
+
       - name: Build sources summary
         run: |
           {
@@ -93,6 +108,7 @@ jobs:
             echo "|-----------|-----------|--------|"
             echo "| SDK | \`${SDK_REPO}\` | \`${SDK_BRANCH}\` |"
             echo "| Wanaku | \`${WANAKU_REPO}\` | \`${WANAKU_BRANCH}\` |"
+            echo "| Barn | \`${BARN_REPO}\` | \`${BARN_BRANCH}\` |"
             echo "| CIC | \`${CIC_REPO}\` | \`${CIC_BRANCH}\` |"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -102,6 +118,14 @@ jobs:
             source/wanaku-sdk/mvnw -B -DskipTests install -f source/wanaku-sdk/pom.xml
           else
             mvn -B -DskipTests install -f source/wanaku-sdk/pom.xml
+          fi
+
+      - name: Build Wanaku Barn
+        run: |
+          if [ -x source/wanaku-barn/mvnw ]; then
+            source/wanaku-barn/mvnw -B -DskipTests install -f source/wanaku-barn/pom.xml
+          else
+            mvn -B -DskipTests install -f source/wanaku-barn/pom.xml
           fi
 
       - name: Build Wanaku Praxis (Rust)
@@ -126,15 +150,11 @@ jobs:
       - name: Resolve CLI path
         id: cli
         run: |
-          CLI_PATH=$(find artifacts -name "wanaku" -path "*/bin/*" -type f 2>/dev/null | head -1)
-          if [ -z "$CLI_PATH" ]; then
-            CLI_PATH=$(find artifacts -name "quarkus-run.jar" -path "*wanaku-cli*" 2>/dev/null | head -1)
-          fi
+          CLI_PATH=$(find source/wanaku-barn -name "quarkus-run.jar" -path "*wanaku-cli*/quarkus-app/*" 2>/dev/null | head -1)
           if [ -n "$CLI_PATH" ]; then
-            chmod +x "$CLI_PATH" 2>/dev/null || true
             echo "path=$(pwd)/${CLI_PATH}" >> "$GITHUB_OUTPUT"
           else
-            echo "::warning::CLI not found in built artifacts"
+            echo "::warning::CLI not found in wanaku-barn build output"
           fi
 
       - name: Run integration tests

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -144,6 +144,7 @@ gh workflow run full-integration-test.yml \
   -f wanaku_branch=0.2.x \
   -f sdk_branch=0.2.x \
   -f cic_branch=0.2.x \
+  -f barn_branch=0.2.x \
   -R <your github ID>/wanaku-tests
 ```
 
@@ -174,5 +175,7 @@ gh workflow run full-integration-test.yml \
 | `sdk_branch` | `main` | SDK branch |
 | `cic_repo` | `wanaku-ai/camel-integration-capability` | CIC repository |
 | `cic_branch` | `main` | CIC branch |
+| `barn_repo` | `wanaku-ai/wanaku-barn` | Wanaku Barn repository (Java components, CLI) |
+| `barn_branch` | `main` | Wanaku Barn branch |
 
 <!-- MANUAL ADDITIONS END -->


### PR DESCRIPTION
## Summary

- The wanaku repo (`wanaku-ai/wanaku`) is now 100% Rust — all Java components (CLI, backend) moved to `wanaku-ai/wanaku-barn`
- The `full-integration-test` workflow's "Build Wanaku (Java components)" step fails with `POM file source/wanaku/pom.xml does not exist`
- Remove the dead Maven build step, add `wanaku-barn` as a new source (with `barn_repo`/`barn_branch` inputs), and update CLI resolution to find it from the barn build output
- Clean up the artifact collection script to remove references to Java artifacts that no longer exist in the wanaku repo

## Test plan

- [ ] Trigger `full-integration-test.yml` workflow and verify it no longer fails at the Java build step
- [ ] Verify CLI is resolved from the wanaku-barn build output