### PR TITLE
ci: fix empty PR comment in test summary

### DIFF
--- a/.github/scripts/test-summary.sh
+++ b/.github/scripts/test-summary.sh
@@ -1,31 +1,38 @@
 #!/bin/bash
 set -euo pipefail
 
-echo "## Test Results" >> "$GITHUB_STEP_SUMMARY"
-echo "" >> "$GITHUB_STEP_SUMMARY"
-echo "| Module | Tests | Passed | Failed | Errors | Skipped | Time |" >> "$GITHUB_STEP_SUMMARY"
-echo "|--------|------:|-------:|-------:|-------:|--------:|-----:|" >> "$GITHUB_STEP_SUMMARY"
+SUMMARY_FILE="${1:-test-summary-output.md}"
+
+{
+echo "## Test Results"
+echo ""
+echo "| Module | Tests | Passed | Failed | Errors | Skipped | Time |"
+echo "|--------|------:|-------:|-------:|-------:|--------:|-----:|"
 
 total_tests=0 total_fail=0 total_err=0 total_skip=0 total_time=0
 
 # Extract test modules from parent POM (excludes test-common which has no tests)
-modules=$(grep '<module>' pom.xml | sed 's|.*<module>\(.*\)</module>.*|\1|' | grep -v '^test-common$')
+modules=$(grep '<module>' pom.xml | sed 's|.*<module>\(.*\)</module>.*|\1|' | grep -v '^test-common$' || true)
+
+if [ -z "$modules" ]; then
+  echo "| _(no test modules found)_ | - | - | - | - | - | - |"
+fi
 
 for module in $modules; do
   dir="${module}/target/failsafe-reports"
   if [ ! -d "$dir" ]; then
-    echo "| ${module} | - | - | - | - | - | - |" >> "$GITHUB_STEP_SUMMARY"
+    echo "| ${module} | - | - | - | - | - | - |"
     continue
   fi
 
   mod_tests=0 mod_fail=0 mod_err=0 mod_skip=0 mod_time=0
   for f in "$dir"/TEST-*.xml; do
     [ -f "$f" ] || continue
-    tests=$(grep -oP 'tests="\K[0-9]+' "$f" | head -1)
-    failures=$(grep -oP 'failures="\K[0-9]+' "$f" | head -1)
-    errors=$(grep -oP 'errors="\K[0-9]+' "$f" | head -1)
-    skipped=$(grep -oP 'skipped="\K[0-9]+' "$f" | head -1)
-    time=$(grep -oP 'time="\K[0-9.]+' "$f" | head -1)
+    tests=$(grep -oP 'tests="\K[0-9]+' "$f" | head -1 || true)
+    failures=$(grep -oP 'failures="\K[0-9]+' "$f" | head -1 || true)
+    errors=$(grep -oP 'errors="\K[0-9]+' "$f" | head -1 || true)
+    skipped=$(grep -oP 'skipped="\K[0-9]+' "$f" | head -1 || true)
+    time=$(grep -oP 'time="\K[0-9.]+' "$f" | head -1 || true)
     mod_tests=$((mod_tests + ${tests:-0}))
     mod_fail=$((mod_fail + ${failures:-0}))
     mod_err=$((mod_err + ${errors:-0}))
@@ -34,7 +41,7 @@ for module in $modules; do
   done
 
   passed=$((mod_tests - mod_fail - mod_err - mod_skip))
-  echo "| ${module} | ${mod_tests} | ${passed} | ${mod_fail} | ${mod_err} | ${mod_skip} | ${mod_time}s |" >> "$GITHUB_STEP_SUMMARY"
+  echo "| ${module} | ${mod_tests} | ${passed} | ${mod_fail} | ${mod_err} | ${mod_skip} | ${mod_time}s |"
 
   total_tests=$((total_tests + mod_tests))
   total_fail=$((total_fail + mod_fail))
@@ -44,40 +51,49 @@ for module in $modules; do
 done
 
 total_passed=$((total_tests - total_fail - total_err - total_skip))
-echo "| **Total** | **${total_tests}** | **${total_passed}** | **${total_fail}** | **${total_err}** | **${total_skip}** | **${total_time}s** |" >> "$GITHUB_STEP_SUMMARY"
+echo "| **Total** | **${total_tests}** | **${total_passed}** | **${total_fail}** | **${total_err}** | **${total_skip}** | **${total_time}s** |"
 
 if [ "$total_fail" -gt 0 ] || [ "$total_err" -gt 0 ]; then
-  echo "" >> "$GITHUB_STEP_SUMMARY"
-  echo "### Failed Tests" >> "$GITHUB_STEP_SUMMARY"
-  echo "" >> "$GITHUB_STEP_SUMMARY"
-  for f in **/target/failsafe-reports/TEST-*.xml; do
-    [ -f "$f" ] || continue
-    grep -l 'failures="[1-9]\|errors="[1-9]' "$f" > /dev/null 2>&1 || continue
-    classname=$(grep -oP 'name="\K[^"]+' "$f" | head -1)
-    grep -oP '<testcase name="\K[^"]+' "$f" | while read -r tc; do
-      block=$(sed -n "/<testcase name=\"${tc}\"/,/<\/testcase>/p" "$f")
-      if echo "$block" | grep -q '<failure\|<error'; then
-        echo "- \`${classname}#${tc}\`" >> "$GITHUB_STEP_SUMMARY"
-        msg=$(echo "$block" | grep -oP '<failure message="\K[^"]*' | head -1)
-        type=$(echo "$block" | grep -oP '<failure[^>]* type="\K[^"]*' | head -1)
-        if [ -z "$msg" ]; then
-          msg=$(echo "$block" | grep -oP '<error message="\K[^"]*' | head -1)
-          type=$(echo "$block" | grep -oP '<error[^>]* type="\K[^"]*' | head -1)
-        fi
-        if [ -n "$msg" ]; then
-          msg=$(echo "$msg" | sed 's/&quot;/"/g; s/&lt;/</g; s/&gt;/>/g; s/&amp;/\&/g; s/&apos;/'"'"'/g')
-          if [ ${#msg} -gt 300 ]; then
-            msg="${msg:0:300}..."
+  echo ""
+  echo "### Failed Tests"
+  echo ""
+  for module in $modules; do
+    dir="${module}/target/failsafe-reports"
+    [ -d "$dir" ] || continue
+    for f in "$dir"/TEST-*.xml; do
+      [ -f "$f" ] || continue
+      grep -q 'failures="[1-9]\|errors="[1-9]' "$f" 2>/dev/null || continue
+      classname=$(grep -oP 'name="\K[^"]+' "$f" | head -1 || true)
+      grep -oP '<testcase name="\K[^"]+' "$f" | while read -r tc; do
+        escaped_tc=$(printf '%s\n' "$tc" | sed 's/[[\.*^$()+?{|\\]/\\&/g')
+        block=$(sed -n "/<testcase name=\"${escaped_tc}\"/,/<\/testcase>/p" "$f")
+        if echo "$block" | grep -q '<failure\|<error'; then
+          echo "- \`${classname}#${tc}\`"
+          msg=$(echo "$block" | grep -oP '<failure message="\K[^"]*' | head -1 || true)
+          type=$(echo "$block" | grep -oP '<failure[^>]* type="\K[^"]*' | head -1 || true)
+          if [ -z "$msg" ]; then
+            msg=$(echo "$block" | grep -oP '<error message="\K[^"]*' | head -1 || true)
+            type=$(echo "$block" | grep -oP '<error[^>]* type="\K[^"]*' | head -1 || true)
           fi
-          short_type=""
-          if [ -n "$type" ]; then
-            short_type=$(echo "$type" | sed 's/.*\.//')
-            echo "  > **${short_type}**: ${msg}" >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "  > ${msg}" >> "$GITHUB_STEP_SUMMARY"
+          if [ -n "$msg" ]; then
+            msg=$(echo "$msg" | sed 's/&quot;/"/g; s/&lt;/</g; s/&gt;/>/g; s/&amp;/\&/g; s/&apos;/'"'"'/g')
+            if [ ${#msg} -gt 300 ]; then
+              msg="${msg:0:300}..."
+            fi
+            if [ -n "$type" ]; then
+              short_type=$(echo "$type" | sed 's/.*\.//')
+              echo "  > **${short_type}**: ${msg}"
+            else
+              echo "  > ${msg}"
+            fi
           fi
         fi
-      fi
+      done || true
     done
   done
+fi
+} > "$SUMMARY_FILE"
+
+if [ -n "${GITHUB_STEP_SUMMARY:-}" ]; then
+  cat "$SUMMARY_FILE" >> "$GITHUB_STEP_SUMMARY"
 fi

--- a/.github/workflows/full-integration-test.yml
+++ b/.github/workflows/full-integration-test.yml
@@ -179,7 +179,7 @@ jobs:
 
       - name: Test summary
         if: always()
-        run: ./.github/scripts/test-summary.sh
+        run: ./.github/scripts/test-summary.sh test-summary-output.md
 
       - name: Resolve source repo name
         if: always() && env.PR_NUMBER != ''
@@ -217,7 +217,11 @@ jobs:
             echo "> **Run:** [${RUN_URL}](${RUN_URL})"
             echo "> **Wanaku:** \`${WANAKU_REPO}\` @ \`${WANAKU_BRANCH}\`"
             echo ""
-            cat "$GITHUB_STEP_SUMMARY"
+            if [ -f test-summary-output.md ]; then
+              cat test-summary-output.md
+            else
+              echo "_Test summary not available._"
+            fi
           } > pr-comment.md
 
           EXISTING=$(gh api --paginate "repos/${SOURCE_REPO}/issues/${PR_NUMBER}/comments" \


### PR DESCRIPTION
## Summary

- `$GITHUB_STEP_SUMMARY` is a per-step unique file in GitHub Actions — reading it from the "Post test summary to PR" step returned an empty file, not the content written by `test-summary.sh`. The PR comment has been empty since the feature was introduced.
- `test-summary.sh` was crashing under `set -euo pipefail` when `grep` found no matches inside `$(...)` command substitutions (grep returns exit 1 on no-match, `pipefail` propagates it, `set -e` kills the script).

## Changes

- Write test summary to a regular file (`test-summary-output.md`) that persists across workflow steps
- Append to `$GITHUB_STEP_SUMMARY` at the end so the job summary page still works
- PR comment step reads from the regular file instead of `$GITHUB_STEP_SUMMARY`
- Added `|| true` guards on all grep pipelines where no-match is a valid outcome
- Escape regex metacharacters in parameterized test names before passing to sed
- Handle edge cases: empty module list, missing `$GITHUB_STEP_SUMMARY` variable

## Test plan

- [ ] Trigger `full-integration-test.yml` with a `pr_number` and verify the PR comment contains the test results table
- [ ] Verify the job summary page still shows the test results
- [ ] Verify test-summary.sh no longer fails (step shows ✓ instead of ✗)

## Summary by Sourcery

Persist GitHub Action test summaries across steps and ensure they are correctly included in PR comments without breaking the summary script under strict shell options.

Bug Fixes:
- Fix empty PR test summary comments by writing the summary to a persistent file instead of reading from a step-local $GITHUB_STEP_SUMMARY.
- Prevent test-summary.sh from failing under set -euo pipefail when grep finds no matches, and handle missing modules and GITHUB_STEP_SUMMARY safely.
- Avoid sed regex errors for parameterized test names by escaping metacharacters before use.

CI:
- Update full-integration-test workflow to pass an explicit output file to the test summary script and read PR comments from that file, with a fallback message if absent.